### PR TITLE
Spec generation

### DIFF
--- a/mcc.php
+++ b/mcc.php
@@ -37,6 +37,7 @@ $application->add(new \MCC\Command\UnfoldFormulas());
 $application->add(new \MCC\Command\InstantiateFormulas());
 $application->add(new \MCC\Command\FormulasCheck());
 $application->add(new \MCC\Command\FormulasToText());
+$application->add(new \MCC\Command\FormulasToSpec());
 $application->add(new \MCC\Command\FormulasToVIS());
 $application->add(new \MCC\Command\GenerateC());
 $application->add(new \MCC\Command\GenerateSpec());

--- a/smc/smc.py
+++ b/smc/smc.py
@@ -199,6 +199,8 @@ class BoundedSearch :
             self.__label_states_isfireable (formula)
         elif formula.op == Formula.LEQ :
             self.__label_states_leq (formula)
+        elif formula.op == Formula.EQ :
+            self.__label_states_eq (formula)
         elif formula.op == Formula.NOT :
             self.label_states (formula.sub1)
             self.__label_states_not (formula)
@@ -265,6 +267,24 @@ class BoundedSearch :
             a = self.__label_states_eval_int (marking, formula.sub1)
             b = self.__label_states_eval_int (marking, formula.sub2)
             if a <= b :
+                marking.formulas_sat.add (formula)
+                nr_sat += 1
+
+        print "smc:   %d states sat, %d unsat, 0 undef" % \
+                (nr_sat, len (self.states) - nr_sat)
+
+    def __label_states_eq (self, formula) :
+        print "smc: labelling formula:", formula
+        assert (formula.op == Formula.EQ)
+        assert (formula.sub1 != None)
+        assert (formula.sub2 != None)
+
+        nr_sat = 0
+
+        for marking in self.states :
+            a = self.__label_states_eval_int (marking, formula.sub1)
+            b = self.__label_states_eval_int (marking, formula.sub2)
+            if a == b :
                 marking.formulas_sat.add (formula)
                 nr_sat += 1
 
@@ -621,6 +641,7 @@ class Formula :
     F            = 15
     X            = 16
     U            = 17
+    EQ           = 18
 
     def __init__ (self, op = None, sub1 = None, sub2 = None) :
         self.op = op
@@ -720,7 +741,8 @@ class Formula :
         elif self.op == Formula.TRUE or \
                 self.op == Formula.FALSE or \
                 self.op == Formula.IS_FIREABLE or \
-                self.op == Formula.LEQ :
+                self.op == Formula.LEQ or \
+                self.op == Formula.EQ :
             return
         else :
             raise Exception, '"%s": Formula::rewrite, internal error' % self
@@ -854,6 +876,7 @@ class Formula :
             return self.sub1.__easy_syntax_eq (g.sub1)
         elif self.op == Formula.OR or \
                 self.op == Formula.LEQ or \
+                self.op == Formula.EQ or \
                 self.op == Formula.AND or \
                 self.op == Formula.EU or \
                 self.op == Formula.U :
@@ -877,6 +900,8 @@ class Formula :
             return s + ")"
         elif self.op == Formula.LEQ :
             return "(" + str (self.sub1) + " <= " + str (self.sub2) + ")"
+        elif self.op == Formula.EQ :
+            return "(" + str (self.sub1) + " == " + str (self.sub2) + ")"
         elif self.op == Formula.NOT :
             return "(not " + str (self.sub1) + ")"
         elif self.op == Formula.OR :
@@ -971,6 +996,10 @@ class Formula :
             f.sub2 = Formula.__read_mcc15_parse_formula (net, xmltree[1])
         elif xmltree.tag == '{http://mcc.lip6.fr/}integer-le' :
             f.op = Formula.LEQ
+            f.sub1 = Formula.__read_mcc15_parse_formula (net, xmltree[0])
+            f.sub2 = Formula.__read_mcc15_parse_formula (net, xmltree[1])
+        elif xmltree.tag == '{http://mcc.lip6.fr/}integer-eq' :
+            f.op = Formula.EQ
             f.sub1 = Formula.__read_mcc15_parse_formula (net, xmltree[0])
             f.sub2 = Formula.__read_mcc15_parse_formula (net, xmltree[1])
         elif xmltree.tag == '{http://mcc.lip6.fr/}is-fireable' :

--- a/spec.sh
+++ b/spec.sh
@@ -1,0 +1,40 @@
+#! /bin/bash
+
+mkdir models
+# Download the archive:
+curl http://mcc.lip6.fr/archives/MCC-INPUTS.tgz \
+     -o models/MCC-INPUTS.tgz
+cd models
+# Extract it:
+tar zxf MCC-INPUTS.tgz
+rm MCC-INPUTS.tgz
+cd BenchKit/INPUTS/
+# Remove all colored models:
+rm *-COL-*.tgz
+# Expand all remaining models:
+for file in *.tgz
+do
+  echo ${file}
+  tar zxf ${file}
+  rm ${file}
+  # Remove useless formula files:
+  rm $(find . -name "CTL*")
+  rm $(find . -name "LTL*")
+  rm $(find . -name "Reachability*")
+done
+cd ../../..
+
+# Convert all models to spec:
+php mcc.php model:to-spec \
+    models/BenchKit/INPUTS/
+
+# Generate formulas for all models:
+php mcc.php formula:generate \
+    --output=ReachabilitySpec \
+    --chain \
+    --quantity=10 \
+    --subcategory=ReachabilitySpec \
+    --depth=5  \
+    --no-filtering \
+    models/BenchKit/INPUTS/
+

--- a/src/External/ParseCSV.php
+++ b/src/External/ParseCSV.php
@@ -2,696 +2,724 @@
 
 namespace External;
 
-class ParseCSV {
-	
+class ParseCSV
+{
 /*
 
-	Class: ParseCSV v0.3.2
-	http://code.google.com/p/parsecsv-for-php/
-	
-	
-	Fully conforms to the specifications lined out on wikipedia:
-	 - http://en.wikipedia.org/wiki/Comma-separated_values
-	
-	Based on the concept of Ming Hong Ng's CsvFileParser class:
-	 - http://minghong.blogspot.com/2006/07/csv-parser-for-php.html
-	
-	
-	
-	Copyright (c) 2007 Jim Myhrberg (jim@zydev.info).
+    Class: ParseCSV v0.3.2
+    http://code.google.com/p/parsecsv-for-php/
 
-	Permission is hereby granted, free of charge, to any person obtaining a copy
-	of this software and associated documentation files (the "Software"), to deal
-	in the Software without restriction, including without limitation the rights
-	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-	copies of the Software, and to permit persons to whom the Software is
-	furnished to do so, subject to the following conditions:
+    Fully conforms to the specifications lined out on wikipedia:
+     - http://en.wikipedia.org/wiki/Comma-separated_values
 
-	The above copyright notice and this permission notice shall be included in
-	all copies or substantial portions of the Software.
+    Based on the concept of Ming Hong Ng's CsvFileParser class:
+     - http://minghong.blogspot.com/2006/07/csv-parser-for-php.html
 
-	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-	THE SOFTWARE.
-	
-	
-	
-	Code Examples
-	----------------
-	# general usage
-	$csv = new ParseCSV('data.csv');
-	print_r($csv->data);
-	----------------
-	# tab delimited, and encoding conversion
-	$csv = new ParseCSV();
-	$csv->encoding('UTF-16', 'UTF-8');
-	$csv->delimiter = "\t";
-	$csv->parse('data.tsv');
-	print_r($csv->data);
-	----------------
-	# auto-detect delimiter character
-	$csv = new ParseCSV();
-	$csv->auto('data.csv');
-	print_r($csv->data);
-	----------------
-	# modify data in a csv file
-	$csv = new ParseCSV();
-	$csv->sort_by = 'id';
-	$csv->parse('data.csv');
-	# "4" is the value of the "id" column of the CSV row
-	$csv->data[4] = array('firstname' => 'John', 'lastname' => 'Doe', 'email' => 'john@doe.com');
-	$csv->save();
-	----------------
-	# add row/entry to end of CSV file
-	#  - only recommended when you know the extact sctructure of the file
-	$csv = new ParseCSV();
-	$csv->save('data.csv', array('1986', 'Home', 'Nowhere', ''), true);
-	----------------
-	# convert 2D array to csv data and send headers
-	# to browser to treat output as a file and download it
-	$csv = new ParseCSV();
-	$csv->output (true, 'movies.csv', $array);
-	----------------
-	
+
+
+    Copyright (c) 2007 Jim Myhrberg (jim@zydev.info).
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+
+
+
+    Code Examples
+    ----------------
+    # general usage
+    $csv = new ParseCSV('data.csv');
+    print_r($csv->data);
+    ----------------
+    # tab delimited, and encoding conversion
+    $csv = new ParseCSV();
+    $csv->encoding('UTF-16', 'UTF-8');
+    $csv->delimiter = "\t";
+    $csv->parse('data.tsv');
+    print_r($csv->data);
+    ----------------
+    # auto-detect delimiter character
+    $csv = new ParseCSV();
+    $csv->auto('data.csv');
+    print_r($csv->data);
+    ----------------
+    # modify data in a csv file
+    $csv = new ParseCSV();
+    $csv->sort_by = 'id';
+    $csv->parse('data.csv');
+    # "4" is the value of the "id" column of the CSV row
+    $csv->data[4] = array('firstname' => 'John', 'lastname' => 'Doe', 'email' => 'john@doe.com');
+    $csv->save();
+    ----------------
+    # add row/entry to end of CSV file
+    #  - only recommended when you know the extact sctructure of the file
+    $csv = new ParseCSV();
+    $csv->save('data.csv', array('1986', 'Home', 'Nowhere', ''), true);
+    ----------------
+    # convert 2D array to csv data and send headers
+    # to browser to treat output as a file and download it
+    $csv = new ParseCSV();
+    $csv->output (true, 'movies.csv', $array);
+    ----------------
+
 
 */
 
 
-	/**
-	 * Configuration
-	 * - set these options with $object->var_name = 'value';
-	 */
-	
-	# use first line/entry as field names
-	var $heading = true;
-	
-	# override field names
-	var $fields = array();
-	
-	# sort entries by this field
-	var $sort_by = null;
-	var $sort_reverse = false;
-	
-	# delimiter (comma) and enclosure (double quote)
-	var $delimiter = ',';
-	var $enclosure = '"';
-	
-	# basic SQL-like conditions for row matching
-	var $conditions = null;
-	
-	# number of rows to ignore from beginning of data
-	var $offset = null;
-	
-	# limits the number of returned rows to specified amount
-	var $limit = null;
-	
-	# number of rows to analyze when attempting to auto-detect delimiter
-	var $auto_depth = 15;
-	
-	# characters to ignore when attempting to auto-detect delimiter
-	var $auto_non_chars = "a-zA-Z0-9\n\r";
-	
-	# preferred delimiter characters, only used when all filtering method
-	# returns multiple possible delimiters (happens very rarely)
-	var $auto_preferred = ",;\t.:|";
-	
-	# character encoding options
-	var $convert_encoding = false;
-	var $input_encoding = 'ISO-8859-1';
-	var $output_encoding = 'ISO-8859-1';
-	
-	# used by unparse(), save(), and output() functions
-	var $linefeed = "\r\n";
-	
-	# only used by output() function
-	var $output_delimiter = ',';
-	var $output_filename = 'data.csv';
-	
-	
-	/**
-	 * Internal variables
-	 */
-	
-	# current file
-	var $file;
-	
-	# loaded file contents
-	var $file_data;
-	
-	# array of field values in data parsed
-	var $titles = array();
-	
-	# two dimentional array of CSV data
-	var $data = array();
-	
-	
-	/**
-	 * Constructor
-	 * @param   input   CSV file or string
-	 * @return  nothing
-	 */
-	function __construct ($input = null, $offset = null, $limit = null, $conditions = null) {
-		if ( $offset !== null ) $this->offset = $offset;
-		if ( $limit !== null ) $this->limit = $limit;
-		if ( count($conditions) > 0 ) $this->conditions = $conditions;
-		if ( !empty($input) ) $this->parse($input);
-	}
-	
-	
-	// ==============================================
-	// ----- [ Main Functions ] ---------------------
-	// ==============================================
-	
-	/**
-	 * Parse CSV file or string
-	 * @param   input   CSV file or string
-	 * @return  nothing
-	 */
-	function parse ($input = null, $offset = null, $limit = null, $conditions = null) {
-		if ( !empty($input) ) {
-			if ( $offset !== null ) $this->offset = $offset;
-			if ( $limit !== null ) $this->limit = $limit;
-			if ( count($conditions) > 0 ) $this->conditions = $conditions;
-			if ( is_readable($input) ) {
-				$this->data = $this->parse_file($input);
-			} else {
-				$this->file_data = &$input;
-				$this->data = $this->parse_string();
-			}
-			if ( $this->data === false ) return false;
-		}
-		return true;
-	}
-	
-	/**
-	 * Save changes, or new file and/or data
-	 * @param   file     file to save to
-	 * @param   data     2D array with data
-	 * @param   append   append current data to end of target CSV if exists
-	 * @param   fields   field names
-	 * @return  true or false
-	 */
-	function save ($file = null, $data = array(), $append = false, $fields = array()) {
-		if ( empty($file) ) $file = &$this->file;
-		$mode = ( $append ) ? 'at' : 'wt' ;
-		$is_php = ( preg_match('/\.php$/i', $file) ) ? true : false ;
-		return $this->_wfile($file, $this->unparse($data, $fields, $append, $is_php), $mode);
-	}
-	
-	/**
-	 * Generate CSV based string for output
-	 * @param   output      if true, prints headers and strings to browser
-	 * @param   filename    filename sent to browser in headers if output is true
-	 * @param   data        2D array with data
-	 * @param   fields      field names
-	 * @param   delimiter   delimiter used to separate data
-	 * @return  CSV data using delimiter of choice, or default
-	 */
-	function output ($output = true, $filename = null, $data = array(), $fields = array(), $delimiter = null) {
-		if ( empty($filename) ) $filename = $this->output_filename;
-		if ( $delimiter === null ) $delimiter = $this->output_delimiter;
-		$data = $this->unparse($data, $fields, null, null, $delimiter);
-		if ( $output ) {
-			header('Content-type: application/csv');
-			header('Content-Disposition: inline; filename="'.$filename.'"');
-			echo $data;
-		}
-		return $data;
-	}
-	
-	/**
-	 * Convert character encoding
-	 * @param   input    input character encoding, uses default if left blank
-	 * @param   output   output character encoding, uses default if left blank
-	 * @return  nothing
-	 */
-	function encoding ($input = null, $output = null) {
-		$this->convert_encoding = true;
-		if ( $input !== null ) $this->input_encoding = $input;
-		if ( $output !== null ) $this->output_encoding = $output;
-	}
-	
-	/**
-	 * Auto-Detect Delimiter: Find delimiter by analyzing a specific number of
-	 * rows to determine most probable delimiter character
-	 * @param   file           local CSV file
-	 * @param   parse          true/false parse file directly
-	 * @param   search_depth   number of rows to analyze
-	 * @param   preferred      preferred delimiter characters
-	 * @param   enclosure      enclosure character, default is double quote (").
-	 * @return  delimiter character
-	 */
-	function auto ($file = null, $parse = true, $search_depth = null, $preferred = null, $enclosure = null) {
-		
-		if ( $file === null ) $file = $this->file;
-		if ( empty($search_depth) ) $search_depth = $this->auto_depth;
-		if ( $enclosure === null ) $enclosure = $this->enclosure;
-		
-		if ( $preferred === null ) $preferred = $this->auto_preferred;
-		
-		if ( empty($this->file_data) ) {
-			if ( $this->_check_data($file) ) {
-				$data = &$this->file_data;
-			} else return false;
-		} else {
-			$data = &$this->file_data;
-		}
-		
-		$chars = array();
-		$strlen = strlen($data);
-		$enclosed = false;
-		$n = 1;
-		$to_end = true;
-		
-		// walk specific depth finding posssible delimiter characters
-		for ( $i=0; $i < $strlen; $i++ ) {
-			$ch = $data{$i};
-			$nch = ( isset($data{$i+1}) ) ? $data{$i+1} : false ;
-			$pch = ( isset($data{$i-1}) ) ? $data{$i-1} : false ;
-			
-			// open and closing quotes
-			if ( $ch == $enclosure && (!$enclosed || $nch != $enclosure) ) {
-				$enclosed = ( $enclosed ) ? false : true ;
-			
-			// inline quotes	
-			} elseif ( $ch == $enclosure && $enclosed ) {
-				$i++;
+    /**
+     * Configuration
+     * - set these options with $object->var_name = 'value';
+     */
 
-			// end of row
-			} elseif ( ($ch == "\n" && $pch != "\r" || $ch == "\r") && !$enclosed ) {
-				if ( $n >= $search_depth ) {
-					$strlen = 0;
-					$to_end = false;
-				} else {
-					$n++;
-				}
-				
-			// count character
-			} elseif (!$enclosed) {
-				if ( !preg_match('/['.preg_quote($this->auto_non_chars, '/').']/i', $ch) ) {
-					if ( !isset($chars[$ch][$n]) ) {
-						$chars[$ch][$n] = 1;
-					} else {
-						$chars[$ch][$n]++;
-					}
-				}
-			}
-		}
-		
-		// filtering
-		$depth = ( $to_end ) ? $n-1 : $n ;
-		$filtered = array();
-		foreach( $chars as $char => $value ) {
-			if ( $match = $this->_check_count($char, $value, $depth, $preferred) ) {
-				$filtered[$match] = $char;
-			}
-		}
-		
-		// capture most probable delimiter
-		ksort($filtered);
-		$delimiter = reset($filtered);
-		$this->delimiter = $delimiter;
-		
-		// parse data
-		if ( $parse ) $this->data = $this->parse_string();
-		
-		return $delimiter;
-		
-	}
-	
-	
-	// ==============================================
-	// ----- [ Core Functions ] ---------------------
-	// ==============================================
-	
-	/**
-	 * Read file to string and call parse_string()
-	 * @param   file   local CSV file
-	 * @return  2D array with CSV data, or false on failure
-	 */
-	function parse_file ($file = null) {
-		if ( $file === null ) $file = $this->file;
-		if ( empty($this->file_data) ) $this->load_data($file);
-		return ( !empty($this->file_data) ) ? $this->parse_string() : false ;
-	}
-	
-	/**
-	 * Parse CSV strings to arrays
-	 * @param   data   CSV string
-	 * @return  2D array with CSV data, or false on failure
-	 */
-	function parse_string ($data = null) {
-		if ( empty($data) ) {
-			if ( $this->_check_data() ) {
-				$data = &$this->file_data;
-			} else return false;
-		}
-		
-		$rows = array();
-		$row = array();
-		$row_count = 0;
-		$current = '';
-		$head = ( !empty($this->fields) ) ? $this->fields : array() ;
-		$col = 0;
-		$enclosed = false;
-		$was_enclosed = false;
-		$strlen = strlen($data);
-		
-		// walk through each character
-		for ( $i=0; $i < $strlen; $i++ ) {
-			$ch = $data{$i};
-			$nch = ( isset($data{$i+1}) ) ? $data{$i+1} : false ;
-			$pch = ( isset($data{$i-1}) ) ? $data{$i-1} : false ;
-			
-			// open and closing quotes
-			if ( $ch == $this->enclosure && (!$enclosed || $nch != $this->enclosure) ) {
-				$enclosed = ( $enclosed ) ? false : true ;
-				if ( $enclosed ) $was_enclosed = true;
-			
-			// inline quotes	
-			} elseif ( $ch == $this->enclosure && $enclosed ) {
-				$current .= $ch;
-				$i++;
+    # use first line/entry as field names
+    public $heading = true;
 
-			// end of field/row
-			} elseif ( ($ch == $this->delimiter || ($ch == "\n" && $pch != "\r") || $ch == "\r") && !$enclosed ) {
-				if ( !$was_enclosed ) $current = trim($current);
-				$key = ( !empty($head[$col]) ) ? $head[$col] : $col ;
-				$row[$key] = $current;
-				$current = '';
-				$col++;
-			
-				// end of row
-				if ( $ch == "\n" || $ch == "\r" ) {
-					if ( $this->_validate_offset($row_count) && $this->_validate_row_conditions($row, $this->conditions) ) {
-						if ( $this->heading && empty($head) ) {
-							$head = $row;
-						} elseif ( empty($this->fields) || (!empty($this->fields) && (($this->heading && $row_count > 0) || !$this->heading)) ) {
-							if ( !empty($this->sort_by) && !empty($row[$this->sort_by]) ) {
-								if ( isset($rows[$row[$this->sort_by]]) ) {
-									$rows[$row[$this->sort_by].'_0'] = &$rows[$row[$this->sort_by]];
-									unset($rows[$row[$this->sort_by]]);
-									for ( $sn=1; isset($rows[$row[$this->sort_by].'_'.$sn]); $sn++ ) {}
-									$rows[$row[$this->sort_by].'_'.$sn] = $row;
-								} else $rows[$row[$this->sort_by]] = $row;
-							} else $rows[] = $row;
-						}
-					}
-					$row = array();
-					$col = 0;
-					$row_count++;
-					if ( $this->sort_by === null && $this->limit !== null && count($rows) == $this->limit ) {
-						$i = $strlen;
-					}
-				}
-				
-			// append character to current field
-			} else {
-				$current .= $ch;
-			}
-		}
-		$this->titles = $head;
-		if ( !empty($this->sort_by) ) {
-			( $this->sort_reverse ) ? krsort($rows) : ksort($rows) ;
-			if ( $this->offset !== null || $this->limit !== null ) {
-				$rows = array_slice($rows, ($this->offset === null ? 0 : $this->offset) , $this->limit, true);
-			}
-		}
-		return $rows;
-	}
-	
-	/**
-	 * Create CSV data from array
-	 * @param   data        2D array with data
-	 * @param   fields      field names
-	 * @param   append      if true, field names will not be output
-	 * @param   is_php      if a php die() call should be put on the first
-	 *                      line of the file, this is later ignored when read.
-	 * @param   delimiter   field delimiter to use
-	 * @return  CSV data (text string)
-	 */
-	function unparse ( $data = array(), $fields = array(), $append = false , $is_php = false, $delimiter = null) {
-		if ( !is_array($data) || empty($data) ) $data = &$this->data;
-		if ( !is_array($fields) || empty($fields) ) $fields = &$this->titles;
-		if ( $delimiter === null ) $delimiter = $this->delimiter;
-		
-		$string = ( $is_php ) ? "<?php header('Status: 403'); die(' '); ?>".$this->linefeed : '' ;
-		$entry = array();
-		
-		// create heading
-		if ( $this->heading && !$append ) {
-			foreach( $fields as $key => $value ) {
-				$entry[] = $this->_enclose_value($value);
-			}
-			$string .= implode($delimiter, $entry).$this->linefeed;
-			$entry = array();
-		}
-		
-		// create data
-		foreach( $data as $key => $row ) {
-			foreach( $row as $field => $value ) {
-				$entry[] = $this->_enclose_value($value);
-			}
-			$string .= implode($delimiter, $entry).$this->linefeed;
-			$entry = array();
-		}
-		
-		return $string;
-	}
-	
-	/**
-	 * Load local file or string
-	 * @param   input   local CSV file
-	 * @return  true or false
-	 */
-	function load_data ($input = null) {
-		$data = null;
-		$file = null;
-		if ( $input === null ) {
-			$file = $this->file;
-		} elseif ( file_exists($input) ) {
-			$file = $input;
-		} else {
-			$data = $input;
-		}
-		if ( !empty($data) || $data = $this->_rfile($file) ) {
-			if ( $this->file != $file ) $this->file = $file;
-			if ( preg_match('/\.php$/i', $file) && preg_match('/<\?.*?\?>(.*)/ims', $data, $strip) ) {
-				$data = ltrim($strip[1]);
-			}
-			if ( $this->convert_encoding ) $data = iconv($this->input_encoding, $this->output_encoding, $data);
-			if ( substr($data, -1) != "\n" ) $data .= "\n";
-			$this->file_data = &$data;
-			return true;
-		}
-		return false;
-	}
-	
-	
-	// ==============================================
-	// ----- [ Internal Functions ] -----------------
-	// ==============================================
-	
-	/**
-	 * Validate a row against specified conditions
-	 * @param   row          array with values from a row
-	 * @param   conditions   specified conditions that the row must match 
-	 * @return  true of false
-	 */
-	function _validate_row_conditions ($row = array(), $conditions = null) {
-		if ( !empty($row) ) {
-			if ( !empty($conditions) ) {
-				$conditions = (strpos($conditions, ' OR ') !== false) ? explode(' OR ', $conditions) : array($conditions) ;
-				$or = '';
-				foreach( $conditions as $key => $value ) {
-					if ( strpos($value, ' AND ') !== false ) {
-						$value = explode(' AND ', $value);
-						$and = '';
-						foreach( $value as $k => $v ) {
-							$and .= $this->_validate_row_condition($row, $v);
-						}
-						$or .= (strpos($and, '0') !== false) ? '0' : '1' ;
-					} else {
-						$or .= $this->_validate_row_condition($row, $value);
-					}
-				}
-				return (strpos($or, '1') !== false) ? true : false ;
-			}
-			return true;
-		}
-		return false;
-	}
-	
-	/**
-	 * Validate a row against a single condition
-	 * @param   row          array with values from a row
-	 * @param   condition   specified condition that the row must match 
-	 * @return  true of false
-	 */
-	function _validate_row_condition ($row, $condition) {
-		$operators = array(
-			'=', 'equals', 'is',
-			'!=', 'is not',
-			'<', 'is less than',
-			'>', 'is greater than',
-			'<=', 'is less than or equals',
-			'>=', 'is greater than or equals',
-			'contains',
-			'does not contain',
-		);
-		$operators_regex = array();
-		foreach( $operators as $value ) {
-			$operators_regex[] = preg_quote($value, '/');
-		}
-		$operators_regex = implode('|', $operators_regex);
-		if ( preg_match('/^(.+) ('.$operators_regex.') (.+)$/i', trim($condition), $capture) ) {
-			$field = $capture[1];
-			$op = $capture[2];
-			$value = $capture[3];
-			if ( preg_match('/^([\'\"]{1})(.*)([\'\"]{1})$/i', $value, $capture) ) {
-				if ( $capture[1] == $capture[3] ) {
-					$value = $capture[2];
-					$value = str_replace("\\n", "\n", $value);
-					$value = str_replace("\\r", "\r", $value);
-					$value = str_replace("\\t", "\t", $value);
-					$value = stripslashes($value);
-				}
-			}
-			if ( array_key_exists($field, $row) ) {
-				if ( ($op == '=' || $op == 'equals' || $op == 'is') && $row[$field] == $value ) {
-					return '1';
-				} elseif ( ($op == '!=' || $op == 'is not') && $row[$field] != $value ) {
-					return '1';
-				} elseif ( ($op == '<' || $op == 'is less than' ) && $row[$field] < $value ) {
-					return '1';
-				} elseif ( ($op == '>' || $op == 'is greater than') && $row[$field] > $value ) {
-					return '1';
-				} elseif ( ($op == '<=' || $op == 'is less than or equals' ) && $row[$field] <= $value ) {
-					return '1';
-				} elseif ( ($op == '>=' || $op == 'is greater than or equals') && $row[$field] >= $value ) {
-					return '1';
-				} elseif ( $op == 'contains' && preg_match('/'.preg_quote($value, '/').'/i', $row[$field]) ) {
-					return '1';
-				} elseif ( $op == 'does not contain' && !preg_match('/'.preg_quote($value, '/').'/i', $row[$field]) ) {
-					return '1';
-				} else {
-					return '0';
-				}
-			}
-		}
-		return '1';
-	}
-	
-	/**
-	 * Validates if the row is within the offset or not if sorting is disabled
-	 * @param   current_row   the current row number being processed
-	 * @return  true of false
-	 */
-	function _validate_offset ($current_row) {
-		if ( $this->sort_by === null && $this->offset !== null && $current_row < $this->offset ) return false;
-		return true;
-	}
-	
-	/**
-	 * Enclose values if needed
-	 *  - only used by unparse()
-	 * @param   value   string to process
-	 * @return  Processed value
-	 */
-	function _enclose_value ($value = null) {
-		if ( $value !== null && $value != '' ) {
-			$delimiter = preg_quote($this->delimiter, '/');
-			$enclosure = preg_quote($this->enclosure, '/');
-			if ( preg_match("/".$delimiter."|".$enclosure."|\n|\r/i", $value) || ($value{0} == ' ' || substr($value, -1) == ' ') ) {
-				$value = str_replace($this->enclosure, $this->enclosure.$this->enclosure, $value);
-				$value = $this->enclosure.$value.$this->enclosure;
-			}
-		}
-		return $value;
-	}
-	
-	/**
-	 * Check file data
-	 * @param   file   local filename
-	 * @return  true or false
-	 */
-	function _check_data ($file = null) {
-		if ( empty($this->file_data) ) {
-			if ( $file === null ) $file = $this->file;
-			return $this->load_data($file);
-		}
-		return true;
-	}
-	
-	
-	/**
-	 * Check if passed info might be delimiter
-	 *  - only used by find_delimiter()
-	 * @return  special string used for delimiter selection, or false
-	 */
-	function _check_count ($char, $array, $depth, $preferred) {
-		if ( $depth == count($array) ) {
-			$first = null;
-			$equal = null;
-			$almost = false;
-			foreach( $array as $key => $value ) {
-				if ( $first == null ) {
-					$first = $value;
-				} elseif ( $value == $first && $equal !== false) {
-					$equal = true;
-				} elseif ( $value == $first+1 && $equal !== false ) {
-					$equal = true;
-					$almost = true;
-				} else {
-					$equal = false;
-				}
-			}
-			if ( $equal ) {
-				$match = ( $almost ) ? 2 : 1 ;
-				$pref = strpos($preferred, $char);
-				$pref = ( $pref !== false ) ? str_pad($pref, 3, '0', STR_PAD_LEFT) : '999' ;
-				return $pref.$match.'.'.(99999 - str_pad($first, 5, '0', STR_PAD_LEFT));
-			} else return false;
-		}
-	}
-	
-	/**
-	 * Read local file
-	 * @param   file   local filename
-	 * @return  Data from file, or false on failure
-	 */
-	function _rfile ($file = null) {
-		if ( is_readable($file) ) {
-			if ( !($fh = fopen($file, 'r')) ) return false;
-			$data = fread($fh, filesize($file));
-			fclose($fh);
-			return $data;
-		}
-		return false;
-	}
+    # override field names
+    public $fields = array();
 
-	/**
-	 * Write to local file
-	 * @param   file     local filename
-	 * @param   string   data to write to file
-	 * @param   mode     fopen() mode
-	 * @param   lock     flock() mode
-	 * @return  true or false
-	 */
-	function _wfile ($file, $string = '', $mode = 'wb', $lock = 2) {
-		if ( $fp = fopen($file, $mode) ) {
-			flock($fp, $lock);
-			$re = fwrite($fp, $string);
-			$re2 = fclose($fp);
-			if ( $re != false && $re2 != false ) return true;
-		}
-		return false;
-	}
-	
+    # sort entries by this field
+    public $sort_by = null;
+    public $sort_reverse = false;
+
+    # delimiter (comma) and enclosure (double quote)
+    public $delimiter = ',';
+    public $enclosure = '"';
+
+    # basic SQL-like conditions for row matching
+    public $conditions = null;
+
+    # number of rows to ignore from beginning of data
+    public $offset = null;
+
+    # limits the number of returned rows to specified amount
+    public $limit = null;
+
+    # number of rows to analyze when attempting to auto-detect delimiter
+    public $auto_depth = 15;
+
+    # characters to ignore when attempting to auto-detect delimiter
+    public $auto_non_chars = "a-zA-Z0-9\n\r";
+
+    # preferred delimiter characters, only used when all filtering method
+    # returns multiple possible delimiters (happens very rarely)
+    public $auto_preferred = ",;\t.:|";
+
+    # character encoding options
+    public $convert_encoding = false;
+    public $input_encoding = 'ISO-8859-1';
+    public $output_encoding = 'ISO-8859-1';
+
+    # used by unparse(), save(), and output() functions
+    public $linefeed = "\r\n";
+
+    # only used by output() function
+    public $output_delimiter = ',';
+    public $output_filename = 'data.csv';
+
+
+    /**
+     * Internal variables
+     */
+
+    # current file
+    public $file;
+
+    # loaded file contents
+    public $file_data;
+
+    # array of field values in data parsed
+    public $titles = array();
+
+    # two dimentional array of CSV data
+    public $data = array();
+
+
+    /**
+     * Constructor
+     * @param   input   CSV file or string
+     * @return nothing
+     */
+    public function __construct($input = null, $offset = null, $limit = null, $conditions = null)
+    {
+        if ( $offset !== null ) $this->offset = $offset;
+        if ( $limit !== null ) $this->limit = $limit;
+        if ( count($conditions) > 0 ) $this->conditions = $conditions;
+        if ( !empty($input) ) $this->parse($input);
+    }
+
+
+    // ==============================================
+    // ----- [ Main Functions ] ---------------------
+    // ==============================================
+
+    /**
+     * Parse CSV file or string
+     * @param   input   CSV file or string
+     * @return nothing
+     */
+    public function parse($input = null, $offset = null, $limit = null, $conditions = null)
+    {
+        if ( !empty($input) ) {
+            if ( $offset !== null ) $this->offset = $offset;
+            if ( $limit !== null ) $this->limit = $limit;
+            if ( count($conditions) > 0 ) $this->conditions = $conditions;
+            if ( is_readable($input) ) {
+                $this->data = $this->parse_file($input);
+            } else {
+                $this->file_data = &$input;
+                $this->data = $this->parse_string();
+            }
+            if ( $this->data === false ) return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Save changes, or new file and/or data
+     * @param   file     file to save to
+     * @param   data     2D array with data
+     * @param   append   append current data to end of target CSV if exists
+     * @param   fields   field names
+     * @return true or false
+     */
+    public function save ($file = null, $data = array(), $append = false, $fields = array())
+    {
+        if ( empty($file) ) $file = &$this->file;
+        $mode = ( $append ) ? 'at' : 'wt' ;
+        $is_php = ( preg_match('/\.php$/i', $file) ) ? true : false ;
+
+        return $this->_wfile($file, $this->unparse($data, $fields, $append, $is_php), $mode);
+    }
+
+    /**
+     * Generate CSV based string for output
+     * @param   output      if true, prints headers and strings to browser
+     * @param   filename    filename sent to browser in headers if output is true
+     * @param   data        2D array with data
+     * @param   fields      field names
+     * @param   delimiter   delimiter used to separate data
+     * @return CSV data using delimiter of choice, or default
+     */
+    public function output ($output = true, $filename = null, $data = array(), $fields = array(), $delimiter = null)
+    {
+        if ( empty($filename) ) $filename = $this->output_filename;
+        if ( $delimiter === null ) $delimiter = $this->output_delimiter;
+        $data = $this->unparse($data, $fields, null, null, $delimiter);
+        if ($output) {
+            header('Content-type: application/csv');
+            header('Content-Disposition: inline; filename="'.$filename.'"');
+            echo $data;
+        }
+
+        return $data;
+    }
+
+    /**
+     * Convert character encoding
+     * @param   input    input character encoding, uses default if left blank
+     * @param   output   output character encoding, uses default if left blank
+     * @return nothing
+     */
+    public function encoding($input = null, $output = null)
+    {
+        $this->convert_encoding = true;
+        if ( $input !== null ) $this->input_encoding = $input;
+        if ( $output !== null ) $this->output_encoding = $output;
+    }
+
+    /**
+     * Auto-Detect Delimiter: Find delimiter by analyzing a specific number of
+     * rows to determine most probable delimiter character
+     * @param   file           local CSV file
+     * @param   parse          true/false parse file directly
+     * @param   search_depth   number of rows to analyze
+     * @param   preferred      preferred delimiter characters
+     * @param   enclosure      enclosure character, default is double quote (").
+     * @return delimiter character
+     */
+    public function auto($file = null, $parse = true, $search_depth = null, $preferred = null, $enclosure = null)
+    {
+        if ( $file === null ) $file = $this->file;
+        if ( empty($search_depth) ) $search_depth = $this->auto_depth;
+        if ( $enclosure === null ) $enclosure = $this->enclosure;
+
+        if ( $preferred === null ) $preferred = $this->auto_preferred;
+
+        if ( empty($this->file_data) ) {
+            if ( $this->_check_data($file) ) {
+                $data = &$this->file_data;
+            } else return false;
+        } else {
+            $data = &$this->file_data;
+        }
+
+        $chars = array();
+        $strlen = strlen($data);
+        $enclosed = false;
+        $n = 1;
+        $to_end = true;
+
+        // walk specific depth finding posssible delimiter characters
+        for ($i=0; $i < $strlen; $i++) {
+            $ch = $data{$i};
+            $nch = ( isset($data{$i+1}) ) ? $data{$i+1} : false ;
+            $pch = ( isset($data{$i-1}) ) ? $data{$i-1} : false ;
+
+            // open and closing quotes
+            if ( $ch == $enclosure && (!$enclosed || $nch != $enclosure) ) {
+                $enclosed = ( $enclosed ) ? false : true ;
+
+            // inline quotes
+            } elseif ($ch == $enclosure && $enclosed) {
+                $i++;
+
+            // end of row
+            } elseif ( ($ch == "\n" && $pch != "\r" || $ch == "\r") && !$enclosed ) {
+                if ($n >= $search_depth) {
+                    $strlen = 0;
+                    $to_end = false;
+                } else {
+                    $n++;
+                }
+
+            // count character
+            } elseif (!$enclosed) {
+                if ( !preg_match('/['.preg_quote($this->auto_non_chars, '/').']/i', $ch) ) {
+                    if ( !isset($chars[$ch][$n]) ) {
+                        $chars[$ch][$n] = 1;
+                    } else {
+                        $chars[$ch][$n]++;
+                    }
+                }
+            }
+        }
+
+        // filtering
+        $depth = ( $to_end ) ? $n-1 : $n ;
+        $filtered = array();
+        foreach ($chars as $char => $value) {
+            if ( $match = $this->_check_count($char, $value, $depth, $preferred) ) {
+                $filtered[$match] = $char;
+            }
+        }
+
+        // capture most probable delimiter
+        ksort($filtered);
+        $delimiter = reset($filtered);
+        $this->delimiter = $delimiter;
+
+        // parse data
+        if ( $parse ) $this->data = $this->parse_string();
+        return $delimiter;
+
+    }
+
+    // ==============================================
+    // ----- [ Core Functions ] ---------------------
+    // ==============================================
+
+    /**
+     * Read file to string and call parse_string()
+     * @param   file   local CSV file
+     * @return 2D array with CSV data, or false on failure
+     */
+    public function parse_file($file = null)
+    {
+        if ( $file === null ) $file = $this->file;
+        if ( empty($this->file_data) ) $this->load_data($file);
+        return ( !empty($this->file_data) ) ? $this->parse_string() : false ;
+    }
+
+    /**
+     * Parse CSV strings to arrays
+     * @param   data   CSV string
+     * @return 2D array with CSV data, or false on failure
+     */
+    public function parse_string($data = null)
+    {
+        if ( empty($data) ) {
+            if ( $this->_check_data() ) {
+                $data = &$this->file_data;
+            } else return false;
+        }
+
+        $rows = array();
+        $row = array();
+        $row_count = 0;
+        $current = '';
+        $head = ( !empty($this->fields) ) ? $this->fields : array() ;
+        $col = 0;
+        $enclosed = false;
+        $was_enclosed = false;
+        $strlen = strlen($data);
+
+        // walk through each character
+        for ($i=0; $i < $strlen; $i++) {
+            $ch = $data{$i};
+            $nch = ( isset($data{$i+1}) ) ? $data{$i+1} : false ;
+            $pch = ( isset($data{$i-1}) ) ? $data{$i-1} : false ;
+
+            // open and closing quotes
+            if ( $ch == $this->enclosure && (!$enclosed || $nch != $this->enclosure) ) {
+                $enclosed = ( $enclosed ) ? false : true ;
+                if ( $enclosed ) $was_enclosed = true;
+
+            // inline quotes
+            } elseif ($ch == $this->enclosure && $enclosed) {
+                $current .= $ch;
+                $i++;
+
+            // end of field/row
+            } elseif ( ($ch == $this->delimiter || ($ch == "\n" && $pch != "\r") || $ch == "\r") && !$enclosed ) {
+                if ( !$was_enclosed ) $current = trim($current);
+                $key = ( !empty($head[$col]) ) ? $head[$col] : $col ;
+                $row[$key] = $current;
+                $current = '';
+                $col++;
+
+                // end of row
+                if ($ch == "\n" || $ch == "\r") {
+                    if ( $this->_validate_offset($row_count) && $this->_validate_row_conditions($row, $this->conditions) ) {
+                        if ( $this->heading && empty($head) ) {
+                            $head = $row;
+                        } elseif ( empty($this->fields) || (!empty($this->fields) && (($this->heading && $row_count > 0) || !$this->heading)) ) {
+                            if ( !empty($this->sort_by) && !empty($row[$this->sort_by]) ) {
+                                if ( isset($rows[$row[$this->sort_by]]) ) {
+                                    $rows[$row[$this->sort_by].'_0'] = &$rows[$row[$this->sort_by]];
+                                    unset($rows[$row[$this->sort_by]]);
+                                    for ( $sn=1; isset($rows[$row[$this->sort_by].'_'.$sn]); $sn++ ) {}
+                                    $rows[$row[$this->sort_by].'_'.$sn] = $row;
+                                } else $rows[$row[$this->sort_by]] = $row;
+                            } else $rows[] = $row;
+                        }
+                    }
+                    $row = array();
+                    $col = 0;
+                    $row_count++;
+                    if ( $this->sort_by === null && $this->limit !== null && count($rows) == $this->limit ) {
+                        $i = $strlen;
+                    }
+                }
+
+            // append character to current field
+            } else {
+                $current .= $ch;
+            }
+        }
+        $this->titles = $head;
+        if ( !empty($this->sort_by) ) {
+            ( $this->sort_reverse ) ? krsort($rows) : ksort($rows) ;
+            if ($this->offset !== null || $this->limit !== null) {
+                $rows = array_slice($rows, ($this->offset === null ? 0 : $this->offset) , $this->limit, true);
+            }
+        }
+
+        return $rows;
+    }
+
+    /**
+     * Create CSV data from array
+     * @param   data        2D array with data
+     * @param   fields      field names
+     * @param   append      if true, field names will not be output
+     * @param   is_php      if a php die() call should be put on the first
+     *                      line of the file, this is later ignored when read.
+     * @param   delimiter   field delimiter to use
+     * @return CSV data (text string)
+     */
+    public function unparse ( $data = array(), $fields = array(), $append = false , $is_php = false, $delimiter = null)
+    {
+        if ( !is_array($data) || empty($data) ) $data = &$this->data;
+        if ( !is_array($fields) || empty($fields) ) $fields = &$this->titles;
+        if ( $delimiter === null ) $delimiter = $this->delimiter;
+
+        $string = ( $is_php ) ? "<?php header('Status: 403'); die(' '); ?>".$this->linefeed : '' ;
+        $entry = array();
+
+        // create heading
+        if ($this->heading && !$append) {
+            foreach ($fields as $key => $value) {
+                $entry[] = $this->_enclose_value($value);
+            }
+            $string .= implode($delimiter, $entry).$this->linefeed;
+            $entry = array();
+        }
+
+        // create data
+        foreach ($data as $key => $row) {
+            foreach ($row as $field => $value) {
+                $entry[] = $this->_enclose_value($value);
+            }
+            $string .= implode($delimiter, $entry).$this->linefeed;
+            $entry = array();
+        }
+
+        return $string;
+    }
+
+    /**
+     * Load local file or string
+     * @param   input   local CSV file
+     * @return true or false
+     */
+    public function load_data($input = null)
+    {
+        $data = null;
+        $file = null;
+        if ($input === null) {
+            $file = $this->file;
+        } elseif ( file_exists($input) ) {
+            $file = $input;
+        } else {
+            $data = $input;
+        }
+        if ( !empty($data) || $data = $this->_rfile($file) ) {
+            if ( $this->file != $file ) $this->file = $file;
+            if ( preg_match('/\.php$/i', $file) && preg_match('/<\?.*?\?>(.*)/ims', $data, $strip) ) {
+                $data = ltrim($strip[1]);
+            }
+            if ( $this->convert_encoding ) $data = iconv($this->input_encoding, $this->output_encoding, $data);
+            if ( substr($data, -1) != "\n" ) $data .= "\n";
+            $this->file_data = &$data;
+
+            return true;
+        }
+
+        return false;
+    }
+
+    // ==============================================
+    // ----- [ Internal Functions ] -----------------
+    // ==============================================
+
+    /**
+     * Validate a row against specified conditions
+     * @param   row          array with values from a row
+     * @param   conditions   specified conditions that the row must match
+     * @return true of false
+     */
+    public function _validate_row_conditions ($row = array(), $conditions = null)
+    {
+        if ( !empty($row) ) {
+            if ( !empty($conditions) ) {
+                $conditions = (strpos($conditions, ' OR ') !== false) ? explode(' OR ', $conditions) : array($conditions) ;
+                $or = '';
+                foreach ($conditions as $key => $value) {
+                    if ( strpos($value, ' AND ') !== false ) {
+                        $value = explode(' AND ', $value);
+                        $and = '';
+                        foreach ($value as $k => $v) {
+                            $and .= $this->_validate_row_condition($row, $v);
+                        }
+                        $or .= (strpos($and, '0') !== false) ? '0' : '1' ;
+                    } else {
+                        $or .= $this->_validate_row_condition($row, $value);
+                    }
+                }
+
+                return (strpos($or, '1') !== false) ? true : false ;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Validate a row against a single condition
+     * @param   row          array with values from a row
+     * @param   condition   specified condition that the row must match
+     * @return true of false
+     */
+    public function _validate_row_condition($row, $condition)
+    {
+        $operators = array(
+            '=', 'equals', 'is',
+            '!=', 'is not',
+            '<', 'is less than',
+            '>', 'is greater than',
+            '<=', 'is less than or equals',
+            '>=', 'is greater than or equals',
+            'contains',
+            'does not contain',
+        );
+        $operators_regex = array();
+        foreach ($operators as $value) {
+            $operators_regex[] = preg_quote($value, '/');
+        }
+        $operators_regex = implode('|', $operators_regex);
+        if ( preg_match('/^(.+) ('.$operators_regex.') (.+)$/i', trim($condition), $capture) ) {
+            $field = $capture[1];
+            $op = $capture[2];
+            $value = $capture[3];
+            if ( preg_match('/^([\'\"]{1})(.*)([\'\"]{1})$/i', $value, $capture) ) {
+                if ($capture[1] == $capture[3]) {
+                    $value = $capture[2];
+                    $value = str_replace("\\n", "\n", $value);
+                    $value = str_replace("\\r", "\r", $value);
+                    $value = str_replace("\\t", "\t", $value);
+                    $value = stripslashes($value);
+                }
+            }
+            if ( array_key_exists($field, $row) ) {
+                if ( ($op == '=' || $op == 'equals' || $op == 'is') && $row[$field] == $value ) {
+                    return '1';
+                } elseif ( ($op == '!=' || $op == 'is not') && $row[$field] != $value ) {
+                    return '1';
+                } elseif ( ($op == '<' || $op == 'is less than' ) && $row[$field] < $value ) {
+                    return '1';
+                } elseif ( ($op == '>' || $op == 'is greater than') && $row[$field] > $value ) {
+                    return '1';
+                } elseif ( ($op == '<=' || $op == 'is less than or equals' ) && $row[$field] <= $value ) {
+                    return '1';
+                } elseif ( ($op == '>=' || $op == 'is greater than or equals') && $row[$field] >= $value ) {
+                    return '1';
+                } elseif ( $op == 'contains' && preg_match('/'.preg_quote($value, '/').'/i', $row[$field]) ) {
+                    return '1';
+                } elseif ( $op == 'does not contain' && !preg_match('/'.preg_quote($value, '/').'/i', $row[$field]) ) {
+                    return '1';
+                } else {
+                    return '0';
+                }
+            }
+        }
+
+        return '1';
+    }
+
+    /**
+     * Validates if the row is within the offset or not if sorting is disabled
+     * @param   current_row   the current row number being processed
+     * @return true of false
+     */
+    public function _validate_offset($current_row)
+    {
+        if ( $this->sort_by === null && $this->offset !== null && $current_row < $this->offset ) return false;
+        return true;
+    }
+
+    /**
+     * Enclose values if needed
+     *  - only used by unparse()
+     * @param   value   string to process
+     * @return Processed value
+     */
+    public function _enclose_value($value = null)
+    {
+        if ($value !== null && $value != '') {
+            $delimiter = preg_quote($this->delimiter, '/');
+            $enclosure = preg_quote($this->enclosure, '/');
+            if ( preg_match("/".$delimiter."|".$enclosure."|\n|\r/i", $value) || ($value{0} == ' ' || substr($value, -1) == ' ') ) {
+                $value = str_replace($this->enclosure, $this->enclosure.$this->enclosure, $value);
+                $value = $this->enclosure.$value.$this->enclosure;
+            }
+        }
+
+        return $value;
+    }
+
+    /**
+     * Check file data
+     * @param   file   local filename
+     * @return true or false
+     */
+    public function _check_data($file = null)
+    {
+        if ( empty($this->file_data) ) {
+            if ( $file === null ) $file = $this->file;
+            return $this->load_data($file);
+        }
+
+        return true;
+    }
+
+    /**
+     * Check if passed info might be delimiter
+     *  - only used by find_delimiter()
+     * @return special string used for delimiter selection, or false
+     */
+    public function _check_count($char, $array, $depth, $preferred)
+    {
+        if ( $depth == count($array) ) {
+            $first = null;
+            $equal = null;
+            $almost = false;
+            foreach ($array as $key => $value) {
+                if ($first == null) {
+                    $first = $value;
+                } elseif ($value == $first && $equal !== false) {
+                    $equal = true;
+                } elseif ($value == $first+1 && $equal !== false) {
+                    $equal = true;
+                    $almost = true;
+                } else {
+                    $equal = false;
+                }
+            }
+            if ($equal) {
+                $match = ( $almost ) ? 2 : 1 ;
+                $pref = strpos($preferred, $char);
+                $pref = ( $pref !== false ) ? str_pad($pref, 3, '0', STR_PAD_LEFT) : '999' ;
+
+                return $pref.$match.'.'.(99999 - str_pad($first, 5, '0', STR_PAD_LEFT));
+            } else return false;
+        }
+    }
+
+    /**
+     * Read local file
+     * @param   file   local filename
+     * @return Data from file, or false on failure
+     */
+    public function _rfile($file = null)
+    {
+        if ( is_readable($file) ) {
+            if ( !($fh = fopen($file, 'r')) ) return false;
+            $data = fread($fh, filesize($file));
+            fclose($fh);
+
+            return $data;
+        }
+
+        return false;
+    }
+
+    /**
+     * Write to local file
+     * @param   file     local filename
+     * @param   string   data to write to file
+     * @param   mode     fopen() mode
+     * @param   lock     flock() mode
+     * @return true or false
+     */
+    public function _wfile($file, $string = '', $mode = 'wb', $lock = 2)
+    {
+        if ( $fp = fopen($file, $mode) ) {
+            flock($fp, $lock);
+            $re = fwrite($fp, $string);
+            $re2 = fclose($fp);
+            if ( $re != false && $re2 != false ) return true;
+        }
+
+        return false;
+    }
+
 }
 
 ?>

--- a/src/MCC/Command/Base.php
+++ b/src/MCC/Command/Base.php
@@ -3,7 +3,6 @@ namespace MCC\Command;
 
 use \Symfony\Component\Console\Command\Command;
 use \Symfony\Component\Console\Input\InputInterface;
-use \Symfony\Component\Console\Input\InputOption;
 use \Symfony\Component\Console\Input\InputArgument;
 use \Symfony\Component\Console\Output\OutputInterface;
 use \Symfony\Component\Console\Formatter\OutputFormatterStyle;
@@ -32,7 +31,7 @@ abstract class Base extends Command
   protected $model_name;
   protected $parameter;
   protected $console_input;
-  public    $console_output; // we need it in CheckFormula, sorry !
+  public $console_output; // we need it in CheckFormula, sorry !
   protected $progress;
 
   protected function configure()
@@ -47,14 +46,14 @@ abstract class Base extends Command
   private function load_model($file)
   {
     $model = NULL;
-    if (file_exists($file) and is_file ($file))
-    {
+    if (file_exists($file) and is_file ($file)) {
       $model = simplexml_load_file($file, NULL, LIBXML_COMPACT);
     }
+
     return $model;
   }
 
-  protected final function execute(InputInterface $input, OutputInterface $output)
+  final protected function execute(InputInterface $input, OutputInterface $output)
   {
     $this->console_input  = $input;
     $this->console_output = $output;
@@ -75,15 +74,13 @@ abstract class Base extends Command
     $this->progress->setProgressCharacter('>');
     $this->progress->setBarWidth(25);
 
-    if (!file_exists($this->root) or !is_dir($this->root))
-    {
+    if (!file_exists($this->root) or !is_dir($this->root)) {
       echo "{$this->root} directory does not exist.\n";
       exit(1);
     }
     $model = $input->getArgument('model');
     $parameter = $input->getArgument('parameter');
-    if (!$model && $parameter)
-    {
+    if (!$model && $parameter) {
       echo "Parameter can only be specified if model is given.\n";
       exit(1);
     }
@@ -94,27 +91,20 @@ abstract class Base extends Command
       '-(COL|PT)-' .
       ($parameter ? '(' . $parameter . ')' : '(.*)') .
       '$';
-    foreach (scandir($this->root) as $entry)
-    {
-      if (is_file($this->root . '/' . $entry))
-      {
+    foreach (scandir($this->root) as $entry) {
+      if (is_file($this->root . '/' . $entry)) {
         try {
           $p = new \PharData($this->root . '/' . $entry);
           $p->extractTo($this->root);
           $output->writeln("<command>Expanded</command> file <instance>{$entry}</instance>");
           unlink($this->root . '/' . $entry);
-        }
-        catch (Exception $e)
-        {}
+        } catch (Exception $e) {}
       }
     }
-    foreach (scandir($this->root) as $entry)
-    {
-      if (is_dir($this->root . '/' . $entry))
-      {
+    foreach (scandir($this->root) as $entry) {
+      if (is_dir($this->root . '/' . $entry)) {
         $matches = array();
-        if (preg_match('/' . $regex . '/u', $entry, $matches))
-        {
+        if (preg_match('/' . $regex . '/u', $entry, $matches)) {
           $instances[] = new Instance($matches[1], $matches[3]);
         }
       }
@@ -123,14 +113,12 @@ abstract class Base extends Command
     $model_length = 0;
     $parameter_length = 0;
     $description_length = 0;
-    foreach ($this->getApplication()->all() as $c)
-    {
+    foreach ($this->getApplication()->all() as $c) {
       $description_length =
         max($description_length, strlen($c->getDescription()));
     }
     // Iterate over instances to perform action:
-    foreach ($instances as $instance)
-    {
+    foreach ($instances as $instance) {
       $this->model_name = $instance->model;
       $this->parameter = $instance->parameter;
       $description = str_pad($this->getDescription(), $description_length);
@@ -159,6 +147,7 @@ abstract class Base extends Command
     $dom->formatOutput = true;
     $dom->loadXML($xml->asXml());
     $dom->preserveWhiteSpace = false;
+
     return $dom->saveXML();
   }
 
@@ -175,18 +164,15 @@ abstract class Base extends Command
   // http://stackoverflow.com/questions/4778865/php-simplexml-addchild-with-another-simplexmlelement
   public function xml_adopt($root, $new)
   {
-    if ($new == null)
-    {
+    if ($new == null) {
       $msg = "Error: xml_adopt: not enough operators to generate formula, internal error.";
       throw new \Exception ($msg);
     }
     $node = $root->addChild($new->getName(), (string) $new);
-    foreach($new->attributes() as $attr => $value)
-    {
+    foreach ($new->attributes() as $attr => $value) {
       $node->addAttribute($attr, $value);
     }
-    foreach($new->children() as $ch)
-    {
+    foreach ($new->children() as $ch) {
       $this->xml_adopt($node, $ch);
     }
   }

--- a/src/MCC/Command/CheckUnfolding.php
+++ b/src/MCC/Command/CheckUnfolding.php
@@ -1,9 +1,6 @@
 <?php
 namespace MCC\Command;
 
-use \Symfony\Component\Console\Input\InputInterface;
-use \Symfony\Component\Console\Output\OutputInterface;
-use \MCC\Command\Base;
 use \MCC\Formula\EquivalentElements;
 
 class CheckUnfolding extends Base
@@ -25,19 +22,18 @@ class CheckUnfolding extends Base
   {
     $result = 0;
     $handle = fopen($file, "r");
-    while(! feof($handle))
-    {
+    while (! feof($handle)) {
       $line = fgets($handle);
       $result++;
     }
     fclose($handle);
+
     return $result - 1;
   }
 
   protected function perform()
   {
-    if ($this->sn_model && $this->pt_model)
-    {
+    if ($this->sn_model && $this->pt_model) {
       $dir = dirname($this->pt_file);
       $this->log = fopen("{$dir}/{$this->log_name}", 'w');
       $this->ep = new EquivalentElements($this->sn_model, $this->pt_model);
@@ -52,8 +48,7 @@ class CheckUnfolding extends Base
       $this->progress->finish();
       fclose($this->log);
       $count = $this->lines_of("{$dir}/{$this->log_name}");
-      if ($count > 0)
-      {
+      if ($count > 0) {
         $this->console_output->writeln(
           "<warning>  Problems have been detected, see {$dir}/{$this->log_name} for details.</warning>"
         );
@@ -65,18 +60,15 @@ class CheckUnfolding extends Base
   {
     // Check that all unfolded places belong to a colored one:
     $c = 0;
-    foreach ($this->ep->cplaces as $place)
-    {
+    foreach ($this->ep->cplaces as $place) {
       // Check that all colored places have at least one unfolding:
-      if (count($place->unfolded) == 0)
-      {
+      if (count($place->unfolded) == 0) {
         fwrite($this->log, "Place {$place->id} (named {$place->name}) has no unfolding.\n");
       }
       $c += count($place->unfolded);
       $this->progress->advance();
     }
-    if ($c != count($this->ep->uplaces))
-    {
+    if ($c != count($this->ep->uplaces)) {
       fwrite($this->log, "Unfolded model may use a bigger parameter.\n");
     }
   }
@@ -85,27 +77,23 @@ class CheckUnfolding extends Base
   {
     // Check that the maximum parameter is reached at least once:
     $maximum_reached = array();
-    foreach ($this->ep->cplaces as $place)
-    {
+    foreach ($this->ep->cplaces as $place) {
       $id = $place->id;
       $size = 1;
       $where = 1;
       $max = count($place->domain->values);
       $p = '';
-      foreach ($place->domain->values as $k => $v)
-      {
+      foreach ($place->domain->values as $k => $v) {
         $first = true;
         $last = end($v);
         $p .= '_((' . $last;
-        if ($where != $max)
-        {
+        if ($where != $max) {
           $size *= count($v);
           $p .= '_.*)|([^_]+';
         }
         $where++;
       }
-      for ($i = 0; $i < 2*count($place->domain->values); $i++)
-      {
+      for ($i = 0; $i < 2*count($place->domain->values); $i++) {
         $p .= ')';
       }
       $regex = "^{$place->name}{$p}$";
@@ -113,15 +101,11 @@ class CheckUnfolding extends Base
       // look at the regex!
       $maximum_reached[$id] = false;
       error_reporting(E_ERROR);
-      foreach ($this->ep->uplaces as $uplace)
-      {
-        if ((size < 1000) && preg_match('/' . $regex . '/u', $uplace->name))
-        {
+      foreach ($this->ep->uplaces as $uplace) {
+        if ((size < 1000) && preg_match('/' . $regex . '/u', $uplace->name)) {
           $maximum_reached[$id] = true;
           break;
-        }
-        else if (ereg($regex, $uplace->name))
-        {
+        } elseif (ereg($regex, $uplace->name)) {
           $maximum_reached[$id] = true;
           break;
         }
@@ -130,16 +114,13 @@ class CheckUnfolding extends Base
       $this->progress->advance();
     }
     $n = 0;
-    foreach ($maximum_reached as $i => $b)
-    {
-      if ($b)
-      {
+    foreach ($maximum_reached as $i => $b) {
+      if ($b) {
         $n++;
       }
     }
     $m = count($this->ep->cplaces);
-    if ($n < $m/2)
-    {
+    if ($n < $m/2) {
       fwrite($this->log, "Maximum parameter is reached for only {$n}/{$m} places.\n");
     }
   }
@@ -148,20 +129,16 @@ class CheckUnfolding extends Base
   {
     $c = 0;
     // Check that every transtion has at least one unfolding:
-    foreach ($this->ep->ctransitions as $transition)
-    {
-      if (count($transition->unfolded) == 0)
-      {
+    foreach ($this->ep->ctransitions as $transition) {
+      if (count($transition->unfolded) == 0) {
         fwrite($this->log, "Transition {$transition->id} (named {$transition->name}) has no unfolding.\n");
       }
       $c += count($transition->unfolded);
       $this->progress->advance();
     }
-    if ($c != count($this->ep->utransitions))
-    {
+    if ($c != count($this->ep->utransitions)) {
       fwrite($this->log, "Unfolded model may use a bigger parameter.\n");
     }
   }
 
 }
-

--- a/src/MCC/Command/CleanFormulas.php
+++ b/src/MCC/Command/CleanFormulas.php
@@ -4,7 +4,6 @@ namespace MCC\Command;
 use \Symfony\Component\Console\Input\InputInterface;
 use \Symfony\Component\Console\Output\OutputInterface;
 use \Symfony\Component\Console\Input\InputOption;
-use \MCC\Command\Base;
 
 class CleanFormulas extends Base
 {
@@ -42,17 +41,14 @@ class CleanFormulas extends Base
   protected function perform()
   {
     $files = $this->generated_files();
-    foreach (array( $this->sn_file, $this->pt_file ) as $f)
-    {
+    foreach (array( $this->sn_file, $this->pt_file ) as $f) {
       $quantity = count($files);
       $this->progress->setRedrawFrequency($quantity);
       $this->progress->start($this->console_output, $quantity);
       $dir = dirname($f);
-      foreach ($files as $filename)
-      {
+      foreach ($files as $filename) {
         $file = "{$dir}/{$filename}";
-        if (file_exists($file))
-        {
+        if (file_exists($file)) {
           unlink($file);
         }
         $this->progress->advance();

--- a/src/MCC/Command/FormulasAddNamespace.php
+++ b/src/MCC/Command/FormulasAddNamespace.php
@@ -4,7 +4,6 @@ namespace MCC\Command;
 use \Symfony\Component\Console\Input\InputInterface;
 use \Symfony\Component\Console\Output\OutputInterface;
 use \Symfony\Component\Console\Input\InputOption;
-use \MCC\Command\Base;
 
 class FormulasAddNamespace extends Base
 {
@@ -30,25 +29,23 @@ class FormulasAddNamespace extends Base
 
   protected function perform()
   {
-    if ($this->sn_model != null)
-    {
+    if ($this->sn_model != null) {
       $file = dirname($this->sn_file) . '/' . $this->output;
       $this->convert($file);
     }
-    if ($this->pt_model != null)
-    {
+    if ($this->pt_model != null) {
       $file = dirname($this->pt_file) . '/' . $this->output;
       $this->convert($file);
     }
   }
 
-  private function convert ($file)
+  private function convert($file)
   {
-    if (! file_exists($file))
-    {
+    if (! file_exists($file)) {
       $this->console_output->writeln(
           "  <warning>Formula file '{$file}' does not exist.</warning>"
         );
+
       return;
     }
     $xml = $this->load_xml(file_get_contents($file));

--- a/src/MCC/Command/FormulasCheck.php
+++ b/src/MCC/Command/FormulasCheck.php
@@ -4,7 +4,6 @@ namespace MCC\Command;
 use \Symfony\Component\Console\Input\InputInterface;
 use \Symfony\Component\Console\Output\OutputInterface;
 use \Symfony\Component\Console\Input\InputOption;
-use \MCC\Command\Base;
 use \MCC\Formula\EquivalentElements;
 use \MCC\Formula\CheckFormula;
 
@@ -44,13 +43,12 @@ class FormulasCheck extends Base
     $this->pt_smt = "${pt_path}/test.smt";
     $this->checker = new CheckFormula();
   }
-  
+
   protected function perform()
   {
 //  $this->console_output->writeln("perform " . $this->sn_smt . " " . $this->pt_smt);
     $this->ep = new EquivalentElements($this->sn_model, $this->pt_model);
-    if ($this->sn_model != null)
-    {
+    if ($this->sn_model != null) {
       $this->check
         (
         $this->sn_input,
@@ -60,8 +58,7 @@ class FormulasCheck extends Base
         $this->ep->ctransitions
       );
     }
-    if ($this->pt_model != null)
-    {
+    if ($this->pt_model != null) {
       $this->check(
         $this->pt_input,
         $this->pt_output,
@@ -72,14 +69,14 @@ class FormulasCheck extends Base
     }
   }
 
-  protected function check ($input, $output, $smt, $places, $transitions)
+  protected function check($input, $output, $smt, $places, $transitions)
   {
 //  $this->console_output->writeln("check " . $smt);
-    if (! file_exists($input))
-    {
+    if (! file_exists($input)) {
       $this->console_output->writeln(
         "<error>Formula file {$input} not found.</error>"
       );
+
       return;
     }
     $xml = $this->load_xml(file_get_contents($input));
@@ -88,19 +85,16 @@ class FormulasCheck extends Base
     $this->progress->start($this->console_output, $quantity);
     $n = 0;
     $to_suppress = array();
-    foreach ($xml->property as $property)
-    {
+    foreach ($xml->property as $property) {
       $result = array(true, array(), "");
-      $result = $this->checker->perform_check($property->formula->children()[0], $places, 
+      $result = $this->checker->perform_check($property->formula->children()[0], $places,
                                      $transitions, $smt);
-      
-      if ($result[2] != "")
-      {
+
+      if ($result[2] != "") {
         $result[0] = $result[0] && $this->checker->call_smt($result, $smt);
       }
-      
-      if (!$result[0])
-      {
+
+      if (!$result[0]) {
         $to_suppress[] = $n;
 //        $this->console_output->writeln("On supprime : " . $n);
 //        unset($xml->children()[$n]);
@@ -109,8 +103,7 @@ class FormulasCheck extends Base
       $this->progress->advance();
     }
     $n = 0;
-    foreach ($to_suppress as $i)
-    {
+    foreach ($to_suppress as $i) {
       unset($xml->children()[$i - $n]);
       $n++;
     }
@@ -120,5 +113,4 @@ class FormulasCheck extends Base
     file_put_contents($output, $this->save_xml($xml));
   }
 
-  
 }

--- a/src/MCC/Command/FormulasToSpec.php
+++ b/src/MCC/Command/FormulasToSpec.php
@@ -1,0 +1,218 @@
+<?php
+namespace MCC\Command;
+
+use \Symfony\Component\Console\Input\InputInterface;
+use \Symfony\Component\Console\Output\OutputInterface;
+use \Symfony\Component\Console\Input\InputOption;
+use \MCC\Command\Base;
+use \MCC\Formula\EquivalentElements;
+
+
+// Requires boolstuff package
+class FormulasToSpec extends Base
+{
+
+  protected function configure()
+  {
+    $this
+      ->setName('formula:to-spec')
+      ->setDescription('Convert formulas to .spec target')
+      ->addOption('output', null,
+        InputOption::VALUE_REQUIRED,
+        'File name for formulas output', 'formulas')
+        ;
+    parent::configure();
+  }
+
+  private $pt_input = null;
+  private $pt_output = null;
+
+  protected function pre_perform(InputInterface $input, OutputInterface $output)
+  {
+    $pt_path = dirname($this->pt_file);
+    $this->pt_input  = "${pt_path}/{$input->getOption('output')}.xml";
+    $this->pt_output = "${pt_path}/{$input->getOption('output')}.spec";
+  }
+
+  protected function perform()
+  {
+    if ($this->pt_model != null)
+    {
+      $this->convert(
+        $this->pt_input,
+        $this->pt_output
+      );
+    }
+  }
+
+  private function convert ($input, $output)
+  {
+    if (file_exists($output))
+      unlink($output);
+    if (! file_exists($input))
+    {
+      $this->console_output->writeln(
+        "<error>Formula file {$input} not found.</error>"
+      );
+      return;
+    }
+    $xml = $this->load_xml(file_get_contents($input));
+    $quantity = count($xml->children());
+    $this->progress->setRedrawFrequency(max(1, $quantity / 100));
+    $this->progress->start($this->console_output, $quantity);
+    // Pre-compute arcs:
+    $pre  = array ();
+    foreach ($this->pt_model->net->page->arc as $arc)
+    {
+      $source = (string) $arc->attributes()['source'];
+      $target = (string) $arc->attributes()['target'];
+      if (! array_key_exists ($target, $pre ))
+        $pre  [$target] = array ();
+      $pre  [$target] [] = $arc;
+    }
+    $i = 0;
+    foreach ($this->pt_model->net->page->place as $place)
+      $i++;
+    $padding   = log10 ($i)+3;
+    $variables = array ();
+    $result = array();
+    foreach ($xml->property as $property)
+    {
+      try
+      {
+        $result[] = $this->translate_property($property, $pre, $padding, $variables);
+      }
+      catch (\Exception $e) {}
+      $this->progress->advance();
+    }
+    $this->progress->finish();
+    $result = implode("\n", $result);
+    file_put_contents($output, $result . "\n");
+  }
+
+  private function translate_property($property, &$pre, $padding, &$variables)
+  {
+    $result      = null;
+    $id          = (string) $property->id;
+    $description = (string) $property->description;
+    $formula     = $this->translate_formula($property->formula->children()[0], $pre, $padding, $variables);
+    $output = array ();
+    exec ("echo '${formula}' | booldnf", $output);
+    $output = $output [0];
+    $search  = array ();
+    $replace = array ();
+    foreach ($variables as $key => $value)
+    {
+      $search  [] = $value;
+      $replace [] = $key;
+    }
+    $formula = str_replace ($search, $replace, $formula);
+    $result = <<<EOS
+\t# ID: Property {$id}
+\t# "{$description}"
+\t{$formula}
+EOS;
+    return $result;
+  }
+
+  private function translate_formula($formula, &$pre, $padding, &$variables)
+  {
+    $result = null;
+    switch ((string) $formula->getName())
+    {
+    case 'exists-path':
+      $sub    = $formula->children()[0];
+      $result = $this->translate_formula($sub, $pre, $padding, $variables);
+      break;
+    case 'finally':
+      $sub    = $formula->children()[0];
+      $result = $this->translate_formula($sub, $pre, $padding, $variables);
+      break;
+    case 'is-fireable':
+      $transition = (string) $formula->transition;
+      $targetdisjunction = array();
+      foreach ($formula->transition as $transition)
+      {
+        $id = (string) $transition;
+        $targetconjunction = array();
+        foreach ($pre [$id] as $arc)
+        {
+          $source = (string) $arc->attributes()['source'];
+          $value  = (string) $arc->inscription->text;
+          if (($value == NULL) || ($value == ""))
+            $value = 1;
+          $expression = "${source}>=${value}";
+          if (! isset ($variables [$expression]))
+          {
+            $count = count ($variables)+1;
+            $var   = "v" . str_pad ($count, $padding, "0", STR_PAD_LEFT);
+            $variables [$expression] = $var;
+          }
+          $targetconjunction [] = $variables [$expression];
+        }
+        $targetdisjunction[] = implode("&", $targetconjunction);
+      }
+      $result = implode("|", $targetdisjunction);
+      break;
+    case 'conjunction':
+      $res = array();
+      foreach ($formula->children() as $sub)
+        $res [] = $this->translate_formula ($sub, $pre, $padding, $variables);
+      $result = implode("&", $res);
+      break;
+    case 'disjunction':
+      $res = array();
+      foreach ($formula->children() as $sub)
+        $res [] = $this->translate_formula ($sub, $pre, $padding, $variables);
+      $result = implode("|", $res);
+      break;
+    case 'integer-le':
+      $res = array();
+      foreach ($formula->children() as $sub)
+        $res[] = $this->translate_formula($sub, $pre, $padding, $variables);
+      if (count($res) != 2)
+      {
+        $this->console_output->writeln("<warning>Error: no support for nary le {$formula->getName()}</warning>");
+        throw(new \Exception("unsupported subformula"));
+      }
+      if (is_numeric($res[0]) && !is_numeric($res[1]))
+      {
+        $expression = "${res[1]}>=${res[0]}";
+        if (! isset ($variables [$expression]))
+        {
+          $count = count ($variables)+1;
+          $var   = "v" . str_pad ($i, $padding, "0", STR_PAD_LEFT);
+          $variables [$expression] = $var;
+        }
+        $result = $variables [$expression];
+      }
+      else
+      {
+        $this->console_output->writeln("<warning>Error: no support for sums and/or less-than constraints{$formula->getName()}</warning>");
+        throw (new \Exception ("unsupported subformula"));
+      }
+      break;
+    case 'integer-constant':
+      $result = (string) $formula;
+      break;
+    case 'tokens-count':
+      $res = array();
+      foreach ($formula->place as $place)
+      {
+        $res[] = (string) $place;
+      }
+      if (count($res) != 1)
+      {
+        $this->console_output->writeln("<warning>Error: no support for sums {$formula->getName()}</warning>");
+        throw(new \Exception("unsupported subformula"));
+      }
+      $result = $res[0];
+      break;
+    default:
+      $this->console_output->writeln("<warning>Error: unknown node {$formula->getName()}</warning>");
+      throw(new \Exception("unsupported subformula"));
+    }
+    return $result;
+  }
+
+}

--- a/src/MCC/Command/FormulasToSpec.php
+++ b/src/MCC/Command/FormulasToSpec.php
@@ -4,9 +4,6 @@ namespace MCC\Command;
 use \Symfony\Component\Console\Input\InputInterface;
 use \Symfony\Component\Console\Output\OutputInterface;
 use \Symfony\Component\Console\Input\InputOption;
-use \MCC\Command\Base;
-use \MCC\Formula\EquivalentElements;
-
 
 // Requires boolstuff package
 class FormulasToSpec extends Base
@@ -39,8 +36,7 @@ class FormulasToSpec extends Base
 
   protected function perform()
   {
-    if ($this->pt_model != null)
-    {
+    if ($this->pt_model != null) {
       $error_file = tempnam ($this->pt_path, "sympy-err");
       $descriptorspec = array(
          0 => array("pipe", "r"),
@@ -49,8 +45,7 @@ class FormulasToSpec extends Base
        );
       $this->pipes = array ();
       $process = proc_open('python', $descriptorspec, $this->pipes, $this->pt_path, array ());
-      if (is_resource($process))
-      {
+      if (is_resource($process)) {
         stream_set_blocking ($this->pipes [0], 0);
         stream_set_blocking ($this->pipes [1], 0);
         $preamble = <<<EOS
@@ -67,29 +62,26 @@ EOS;
         );
         fclose ($this->pipes [0]);
         fclose ($this->pipes [1]);
-        if (proc_close($process) != 0)
-        {
+        if (proc_close($process) != 0) {
           $this->console_output->writeln("<error>Error: python errored</error>");
           $reason = file_get_contents ($error_file);
           $this->console_output->writeln("<error>${reason}</error>");
-        }
-        else
+        } else
           unlink ($error_file);
-      }
-      else
+      } else
         $this->console_output->writeln("<error>Error: unable to run python</error>");
     }
   }
 
-  private function convert ($input, $output)
+  private function convert($input, $output)
   {
     if (file_exists($output))
       unlink($output);
-    if (! file_exists($input))
-    {
+    if (! file_exists($input)) {
       $this->console_output->writeln(
         "<error>Formula file {$input} not found.</error>"
       );
+
       return;
     }
     $xml = $this->load_xml(file_get_contents($input));
@@ -98,8 +90,7 @@ EOS;
     $this->progress->start($this->console_output, $quantity);
     // Pre-compute arcs:
     $pre  = array ();
-    foreach ($this->pt_model->net->page->arc as $arc)
-    {
+    foreach ($this->pt_model->net->page->arc as $arc) {
       $source = (string) $arc->attributes()['source'];
       $target = (string) $arc->attributes()['target'];
       if (! array_key_exists ($target, $pre ))
@@ -111,14 +102,11 @@ EOS;
       $i++;
     $padding   = log10 ($i)+3;
     $result = array();
-    foreach ($xml->property as $property)
-    {
-      try
-      {
+    foreach ($xml->property as $property) {
+      try {
         $variables = array ();
         $result[] = $this->translate_property($property, $pre, $padding, $variables);
-      }
-      catch (\Exception $e) {}
+      } catch (\Exception $e) {}
       $this->progress->advance();
     }
     $this->progress->finish();
@@ -135,16 +123,14 @@ EOS;
     $output = array ();
     $search  = array ();
     $replace = array ();
-    foreach ($variables as $key => $value)
-    {
+    foreach ($variables as $key => $value) {
       fwrite ($this->pipes [0], "${value} = symbols (\"${value}\")\n");
       $search  [] = $value;
       $replace [] = $key;
     }
     fwrite ($this->pipes [0], "print (to_dnf (${formula}))\n");
     $output = stream_get_contents ($this->pipes[1]);
-    foreach ($variables as $key => $value)
-    {
+    foreach ($variables as $key => $value) {
       $search  [] = $value;
       $replace [] = $key;
     }
@@ -157,14 +143,14 @@ EOS;
 \t# "{$description}"
 \t{$formula}
 EOS;
+
     return $result;
   }
 
   private function translate_formula($formula, &$pre, $padding, &$variables)
   {
     $result = null;
-    switch ((string) $formula->getName())
-    {
+    switch ((string) $formula->getName()) {
     case 'exists-path':
       $sub    = $formula->children()[0];
       $result = $this->translate_formula($sub, $pre, $padding, $variables);
@@ -176,19 +162,16 @@ EOS;
     case 'is-fireable':
       $transition = (string) $formula->transition;
       $targetdisjunction = array();
-      foreach ($formula->transition as $transition)
-      {
+      foreach ($formula->transition as $transition) {
         $id = (string) $transition;
         $targetconjunction = array();
-        foreach ($pre [$id] as $arc)
-        {
+        foreach ($pre [$id] as $arc) {
           $source = (string) $arc->attributes()['source'];
           $value  = (string) $arc->inscription->text;
           if (($value == NULL) || ($value == ""))
             $value = 1;
           $expression = "${source}>=${value}";
-          if (! isset ($variables [$expression]))
-          {
+          if (! isset ($variables [$expression])) {
             $count = count ($variables)+1;
             $var   = "v" . str_pad ($count, $padding, "0", STR_PAD_LEFT);
             $variables [$expression] = $var;
@@ -215,24 +198,19 @@ EOS;
       $res = array();
       foreach ($formula->children() as $sub)
         $res[] = $this->translate_formula($sub, $pre, $padding, $variables);
-      if (count($res) != 2)
-      {
+      if (count($res) != 2) {
         $this->console_output->writeln("<warning>Error: no support for nary le </warning>");
         throw(new \Exception("unsupported subformula"));
       }
-      if (is_numeric($res[0]) && !is_numeric($res[1]))
-      {
+      if (is_numeric($res[0]) && !is_numeric($res[1])) {
         $expression = "${res[1]}>=${res[0]}";
-        if (! isset ($variables [$expression]))
-        {
+        if (! isset ($variables [$expression])) {
           $count = count ($variables)+1;
           $var   = "v" . str_pad ($count, $padding, "0", STR_PAD_LEFT);
           $variables [$expression] = $var;
         }
         $result = $variables [$expression];
-      }
-      else
-      {
+      } else {
         $this->console_output->writeln("<warning>Error: no support for less-than constraints place<=*</warning>");
         throw (new \Exception ("unsupported subformula"));
       }
@@ -242,12 +220,10 @@ EOS;
       break;
     case 'tokens-count':
       $res = array();
-      foreach ($formula->place as $place)
-      {
+      foreach ($formula->place as $place) {
         $res[] = (string) $place;
       }
-      if (count($res) != 1)
-      {
+      if (count($res) != 1) {
         $this->console_output->writeln("<warning>Error: no support for comparison between places</warning>");
         throw(new \Exception("unsupported subformula"));
       }
@@ -257,6 +233,7 @@ EOS;
       $this->console_output->writeln("<warning>Error: unknown node {$formula->getName()}</warning>");
       throw(new \Exception("unsupported subformula"));
     }
+
     return $result;
   }
 

--- a/src/MCC/Command/FormulasToSpec.php
+++ b/src/MCC/Command/FormulasToSpec.php
@@ -5,7 +5,6 @@ use \Symfony\Component\Console\Input\InputInterface;
 use \Symfony\Component\Console\Output\OutputInterface;
 use \Symfony\Component\Console\Input\InputOption;
 
-// Requires boolstuff package
 class FormulasToSpec extends Base
 {
 

--- a/src/MCC/Command/FormulasToSpec.php
+++ b/src/MCC/Command/FormulasToSpec.php
@@ -12,7 +12,7 @@ class FormulasToSpec extends Base
   {
     $this
       ->setName('formula:to-spec')
-      ->setDescription('Convert formulas to .spec target')
+      ->setDescription('Convert formulas to spec')
       ->addOption('output', null,
         InputOption::VALUE_REQUIRED,
         'File name for formulas output', 'formulas')
@@ -192,6 +192,27 @@ EOS;
       foreach ($formula->children() as $sub)
         $res [] = $this->translate_formula ($sub, $pre, $padding, $variables);
       $result = "(" . implode("|", $res) . ")";
+      break;
+    case 'integer-eq':
+      $res = array();
+      foreach ($formula->children() as $sub)
+        $res[] = $this->translate_formula($sub, $pre, $padding, $variables);
+      if (count($res) != 2) {
+        $this->console_output->writeln("<warning>Error: no support for nary eq </warning>");
+        throw(new \Exception("unsupported subformula"));
+      }
+      if (is_numeric($res[0]) && !is_numeric($res[1])) {
+        $expression = "${res[1]}=${res[0]}";
+        if (! isset ($variables [$expression])) {
+          $count = count ($variables)+1;
+          $var   = "v" . str_pad ($count, $padding, "0", STR_PAD_LEFT);
+          $variables [$expression] = $var;
+        }
+        $result = $variables [$expression];
+      } else {
+        $this->console_output->writeln("<warning>Error: no support for less-than constraints place<=*</warning>");
+        throw (new \Exception ("unsupported subformula"));
+      }
       break;
     case 'integer-le':
       $res = array();

--- a/src/MCC/Command/FormulasToText.php
+++ b/src/MCC/Command/FormulasToText.php
@@ -324,6 +324,13 @@ EOS;
     /*   } */
     /*   $result = '(' . implode(' < ', $res) . ')'; */
     /*   break; */
+    case 'integer-eq':
+      $res = array();
+      foreach ($formula->children() as $sub) {
+        $res[] = $this->translate_formula($sub, $places, $transitions, true);
+      }
+      $result = '(' . implode(' == ', $res) . ')';
+      break;
     case 'integer-le':
       $res = array();
       foreach ($formula->children() as $sub) {

--- a/src/MCC/Command/FormulasToText.php
+++ b/src/MCC/Command/FormulasToText.php
@@ -4,7 +4,6 @@ namespace MCC\Command;
 use \Symfony\Component\Console\Input\InputInterface;
 use \Symfony\Component\Console\Output\OutputInterface;
 use \Symfony\Component\Console\Input\InputOption;
-use \MCC\Command\Base;
 use \MCC\Formula\EquivalentElements;
 
 class FormulasToText extends Base
@@ -41,8 +40,7 @@ class FormulasToText extends Base
   protected function perform()
   {
     $this->ep = new EquivalentElements($this->sn_model, $this->pt_model);
-    if ($this->sn_model != null)
-    {
+    if ($this->sn_model != null) {
       $this->convert(
         $this->sn_input,
         $this->sn_output,
@@ -50,8 +48,7 @@ class FormulasToText extends Base
         $this->ep->ctransitions
       );
     }
-    if ($this->pt_model != null)
-    {
+    if ($this->pt_model != null) {
       $this->convert(
         $this->pt_input,
         $this->pt_output,
@@ -61,15 +58,15 @@ class FormulasToText extends Base
     }
   }
 
-  private function convert ($input, $output, $places, $transitions)
+  private function convert($input, $output, $places, $transitions)
   {
     if (file_exists($output))
       unlink($output);
-    if (! file_exists($input))
-    {
+    if (! file_exists($input)) {
       $this->console_output->writeln(
         "<error>Formula file {$input} not found.</error>"
       );
+
       return;
     }
     $xml = $this->load_xml(file_get_contents($input));
@@ -77,8 +74,7 @@ class FormulasToText extends Base
     $this->progress->setRedrawFrequency(max(1, $quantity / 100));
     $this->progress->start($this->console_output, $quantity);
     $result = array();
-    foreach ($xml->property as $property)
-    {
+    foreach ($xml->property as $property) {
       $result[] = $this->translate_property($property, $places, $transitions);
       $this->progress->advance();
     }
@@ -107,8 +103,7 @@ class FormulasToText extends Base
       $places,
       $transitions
     );
-    if ($property->{'expected-result'})
-    {
+    if ($property->{'expected-result'}) {
       $expected = (string) $property->{'expected-result'}->value;
       $explanation = (string) $property->{'expected-result'}->explanation;
 /*       $result = <<<EOS */
@@ -126,8 +121,7 @@ Property {$id}
     {$formula}
   end.
 EOS;
-    }
-    else {
+    } else {
 /*       $result = <<<EOS */
 /* Property {$id} */
 /*   "{$description}" */
@@ -143,14 +137,14 @@ Property {$id}
   end.
 EOS;
     }
+
     return $result;
   }
 
   private function translate_formula($formula, $places, $transitions, $in_nary = false)
   {
     $result = null;
-    switch ((string) $formula->getName())
-    {
+    switch ((string) $formula->getName()) {
     /* case 'invariant': */
     /*   $sub = $formula->children()[0]; */
     /*   $result = 'I ' . */
@@ -192,7 +186,7 @@ EOS;
       /* } */
       /* $result = "X{$steps}{$succ} " . */
       $sub = $formula->children()[0];
-      $result = 'X ' .  
+      $result = 'X ' .
         $this->translate_formula($sub, $places, $transitions);
       break;
     case 'globally':
@@ -213,7 +207,7 @@ EOS;
       /* if ($strength == 'weak') */
       /* { */
       /*   $operator = 'W'; */
-      /* } else if ($strength == 'strong') */
+      /* } elseif ($strength == 'strong') */
       /* { */
       $operator = 'U';
       /* } */
@@ -246,17 +240,13 @@ EOS;
     /*   break; */
     case 'is-fireable':
       $transition = (string) $formula->transition;
-      foreach ($formula->transition as $transition)
-      {
+      foreach ($formula->transition as $transition) {
         $names[] = $transitions[(string) $transition]->name;
       }
       $name = null;
-      if (count($names) == 1)
-      {
+      if (count($names) == 1) {
         $name = '"' . $names[0] . '"';
-      }
-      else
-      {
+      } else {
         $name = '("' . implode('", "', $names) . '")';
       }
       $result = "{$name}?";
@@ -274,16 +264,14 @@ EOS;
       break;
     case 'conjunction':
       $res = array();
-      foreach ($formula->children() as $sub)
-      {
+      foreach ($formula->children() as $sub) {
         $res[] = $this->translate_formula($sub, $places, $transitions, true);
       }
       $result = '(' . implode(' & ', $res) . ')';
       break;
     case 'disjunction':
       $res = array();
-      foreach ($formula->children() as $sub)
-      {
+      foreach ($formula->children() as $sub) {
         $res[] = $this->translate_formula($sub, $places, $transitions, true);
       }
       $result = '(' . implode(' | ', $res) . ')';
@@ -338,8 +326,7 @@ EOS;
     /*   break; */
     case 'integer-le':
       $res = array();
-      foreach ($formula->children() as $sub)
-      {
+      foreach ($formula->children() as $sub) {
         $res[] = $this->translate_formula($sub, $places, $transitions, true);
       }
       $result = '(' . implode(' <= ', $res) . ')';
@@ -366,8 +353,7 @@ EOS;
       break;
     case 'integer-sum':
       $res = array();
-      foreach ($formula->children() as $sub)
-      {
+      foreach ($formula->children() as $sub) {
         $res[] = $this->translate_formula($sub, $places, $transitions, true);
       }
       $result = '(' . implode(' + ', $res) . ')';
@@ -382,8 +368,7 @@ EOS;
     /*   break; */
     case 'integer-difference':
       $res = array();
-      foreach ($formula->children() as $sub)
-      {
+      foreach ($formula->children() as $sub) {
         $res[] = $this->translate_formula($sub, $places, $transitions, true);
       }
       $result = '(' . implode(' - ', $res) . ')';
@@ -398,8 +383,7 @@ EOS;
     /*   break; */
     case 'place-bound':
       $res = array();
-      foreach ($formula->place as $place)
-      {
+      foreach ($formula->place as $place) {
         $id = (string) $place;
         $name = $places[$id]->name;
         $res[] = '"' . $name . '"';
@@ -408,8 +392,7 @@ EOS;
       break;
     case 'tokens-count':
       $res = array();
-      foreach ($formula->place as $place)
-      {
+      foreach ($formula->place as $place) {
         $id = (string) $place;
         $name = $places[$id]->name;
         $res[] = '"' . $name . '"';
@@ -421,10 +404,10 @@ EOS;
         "<warning>Error: unknown node {$formula->getName()}</warning>"
       );
     }
-    if ($in_nary)
-    {
+    if ($in_nary) {
       $result = "({$result})";
     }
+
     return $result;
   }
 

--- a/src/MCC/Command/FormulasToVIS.php
+++ b/src/MCC/Command/FormulasToVIS.php
@@ -4,8 +4,6 @@ namespace MCC\Command;
 use \Symfony\Component\Console\Input\InputInterface;
 use \Symfony\Component\Console\Output\OutputInterface;
 use \Symfony\Component\Console\Input\InputOption;
-use \MCC\Command\Base;
-use \MCC\Formula\EquivalentElements;
 
 class FormulasToVIS extends Base
 {
@@ -34,8 +32,7 @@ class FormulasToVIS extends Base
 
   protected function perform()
   {
-    if ($this->pt_model != null)
-    {
+    if ($this->pt_model != null) {
       $this->convert(
         $this->pt_input,
         $this->pt_output
@@ -43,15 +40,15 @@ class FormulasToVIS extends Base
     }
   }
 
-  private function convert ($input, $output)
+  private function convert($input, $output)
   {
     if (file_exists($output))
       unlink($output);
-    if (! file_exists($input))
-    {
+    if (! file_exists($input)) {
       $this->console_output->writeln(
         "<error>Formula file {$input} not found.</error>"
       );
+
       return;
     }
     $xml = $this->load_xml(file_get_contents($input));
@@ -60,8 +57,7 @@ class FormulasToVIS extends Base
     $this->progress->start($this->console_output, $quantity);
     $result = array();
     $errors = array();
-    foreach ($xml->property as $property)
-    {
+    foreach ($xml->property as $property) {
       try {
         $result[] = $this->translate_property($property);
       } catch (\Exception $e) {
@@ -91,14 +87,14 @@ class FormulasToVIS extends Base
       true
     );
     $result .= ";\n";
+
     return $result;
   }
 
   private function translate_formula($formula, $in_operator = null)
   {
     $result = null;
-    switch ((string) $formula->getName())
-    {
+    switch ((string) $formula->getName()) {
     case 'invariant':
       $sub = $formula->children()[0];
       $result = 'AG (' .
@@ -134,8 +130,7 @@ class FormulasToVIS extends Base
       }
       $steps = (string) $formula->steps;
       $sub = null;
-      foreach ($formula->children() as $child)
-      {
+      foreach ($formula->children() as $child) {
         if ($child->getName() != 'if-no-successor' &&
             $child->getName() != 'steps')
         {
@@ -176,11 +171,9 @@ class FormulasToVIS extends Base
       $reach  = $formula->reach->children()[0];
       $strength = (string) $formula->strength;
       $operator = null;
-      if ($strength == 'weak')
-      {
+      if ($strength == 'weak') {
         throw new \Exception("W");
-      } else if ($strength == 'strong')
-      {
+      } elseif ($strength == 'strong') {
         $operator = 'U';
       }
       $result = "((" .
@@ -212,48 +205,42 @@ class FormulasToVIS extends Base
       break;
     case 'conjunction':
       $res = array();
-      foreach ($formula->children() as $sub)
-      {
+      foreach ($formula->children() as $sub) {
         $res[] = $this->translate_formula($sub);
       }
       $result = '(' . implode(' * ', $res) . ')';
       break;
     case 'disjunction':
       $res = array();
-      foreach ($formula->children() as $sub)
-      {
+      foreach ($formula->children() as $sub) {
         $res[] = $this->translate_formula($sub);
       }
       $result = '(' . implode(' + ', $res) . ')';
       break;
     case 'exclusive-disjunction':
       $res = array();
-      foreach ($formula->children() as $sub)
-      {
+      foreach ($formula->children() as $sub) {
         $res[] = $this->translate_formula($sub);
       }
       $result = '(' . implode(' ^ ', $res) . ')';
       break;
     case 'implication':
       $res = array();
-      foreach ($formula->children() as $sub)
-      {
+      foreach ($formula->children() as $sub) {
         $res[] = $this->translate_formula($sub);
       }
       $result = '(' . implode(' -> ', $res) . ')';
       break;
     case 'equivalence':
       $res = array();
-      foreach ($formula->children() as $sub)
-      {
+      foreach ($formula->children() as $sub) {
         $res[] = $this->translate_formula($sub);
       }
       $result = '(' . implode(' <-> ', $res) . ')';
       break;
     case 'integer-eq':
       $res = array();
-      foreach ($formula->children() as $sub)
-      {
+      foreach ($formula->children() as $sub) {
         $res[] = $this->translate_formula($sub);
       }
       $result = '(' . implode(' = ', $res) . ')';
@@ -261,8 +248,7 @@ class FormulasToVIS extends Base
       break;
     case 'integer-ne':
       $res = array();
-      foreach ($formula->children() as $sub)
-      {
+      foreach ($formula->children() as $sub) {
         $res[] = $this->translate_formula($sub);
       }
       $result = '! (' . implode(' = ', $res) . ')';
@@ -311,6 +297,7 @@ class FormulasToVIS extends Base
         "<warning>Error: unknown node {$formula->getName()}</warning>"
       );
     }
+
     return $result;
   }
 

--- a/src/MCC/Command/GenerateC.php
+++ b/src/MCC/Command/GenerateC.php
@@ -1,12 +1,6 @@
 <?php
 namespace MCC\Command;
 
-use \Symfony\Component\Console\Input\InputOption;
-use \Symfony\Component\Console\Input\InputArgument;
-use \Symfony\Component\Console\Input\InputInterface;
-use \Symfony\Component\Console\Output\OutputInterface;
-use \MCC\Command\Base;
-
 class GenerateC extends Base
 {
 
@@ -20,8 +14,7 @@ class GenerateC extends Base
 
   protected function perform()
   {
-    if ($this->pt_model == NULL)
-    {
+    if ($this->pt_model == NULL) {
       return;
     }
     $model = $this->pt_model;
@@ -48,8 +41,7 @@ class GenerateC extends Base
     fwrite($fp, "  }\n");
     fwrite($fp, "  state(state&& rhs) = default;\n");
     fwrite($fp, "  state& operator=(state&& rhs) = default;\n");
-    foreach ($model->net->page->place as $place)
-    {
+    foreach ($model->net->page->place as $place) {
       $id = (string) $place->attributes()['id'];
       fwrite($fp, "  MARKING_TYPE ${id};\n");
       $this->progress->advance();
@@ -58,12 +50,10 @@ class GenerateC extends Base
     fwrite($fp, "\n");
     fwrite($fp, "state initial_state() {\n");
     fwrite($fp, "  state result;\n");
-    foreach ($model->net->page->place as $place)
-    {
+    foreach ($model->net->page->place as $place) {
       $id = (string) $place->attributes()['id'];
       $initial = (string) $place->initialMarking->text;
-      if (($initial == NULL) || ($initial == ""))
-      {
+      if (($initial == NULL) || ($initial == "")) {
         $initial = 0;
       }
       fwrite($fp, "  result.${id} = ${initial};\n");
@@ -73,17 +63,14 @@ class GenerateC extends Base
     fwrite($fp, "\n");
     // Build relation between IDs and arcs:
     $lookup = array();
-    foreach ($model->net->page->arc as $arc)
-    {
+    foreach ($model->net->page->arc as $arc) {
       $source = (string) $arc->attributes()['source'];
-      if (! array_key_exists($source, $lookup))
-      {
+      if (! array_key_exists($source, $lookup)) {
         $lookup[$source] = array();
       }
       $lookup[$source][] = $arc;
       $target = (string) $arc->attributes()['target'];
-      if (! array_key_exists($target, $lookup))
-      {
+      if (! array_key_exists($target, $lookup)) {
         $lookup[$target] = array();
       }
       $lookup[$target][] = $arc;
@@ -92,53 +79,43 @@ class GenerateC extends Base
     fwrite($fp, "using result_type = std::unordered_map<std::string, state>;\n");
     fwrite($fp, "result_type next_state (const state& s) {\n");
     fwrite($fp, "  auto result = result_type();\n");
-    foreach ($model->net->page->transition as $transition)
-    {
+    foreach ($model->net->page->transition as $transition) {
       $id = (string) $transition->attributes()['id'];
       $name = (string) $transition->name->text;
       fwrite($fp, "  // Transition ${name} (id: ${id}):\n");
       fwrite($fp, "  if (true");
-      foreach ($lookup[$id] as $arc)
-      {
+      foreach ($lookup[$id] as $arc) {
         $source = (string) $arc->attributes()['source'];
         $target = (string) $arc->attributes()['target'];
         $value  = (string) $arc->inscription->text;
-        if (($value == NULL) || ($value == ""))
-        {
+        if (($value == NULL) || ($value == "")) {
           $value = 1;
         }
-        if ($target == $id)
-        {
+        if ($target == $id) {
           fwrite($fp, " and (s.${source} >= ${value})");
         }
       }
       fwrite($fp, ") {\n");
       fwrite($fp, "    state n = s;\n");
-      foreach ($lookup[$id] as $arc)
-      {
+      foreach ($lookup[$id] as $arc) {
         $source = (string) $arc->attributes()['source'];
         $target = (string) $arc->attributes()['target'];
         $value  = (string) $arc->inscription->text;
-        if (($value == NULL) || ($value == ""))
-        {
+        if (($value == NULL) || ($value == "")) {
           $value = 1;
         }
-        if ($target == $id)
-        {
+        if ($target == $id) {
           fwrite($fp, "    n.${source} -= ${value};\n");
         }
       }
-      foreach ($lookup[$id] as $arc)
-      {
+      foreach ($lookup[$id] as $arc) {
         $source = (string) $arc->attributes()['source'];
         $target = (string) $arc->attributes()['target'];
         $value  = (string) $arc->inscription->text;
-        if (($value == NULL) || ($value == ""))
-        {
+        if (($value == NULL) || ($value == "")) {
           $value = 1;
         }
-        if ($source == $id)
-        {
+        if ($source == $id) {
           fwrite($fp, "    n.${target} += ${value};\n");
         }
       }

--- a/src/MCC/Command/GenerateFormulas.php
+++ b/src/MCC/Command/GenerateFormulas.php
@@ -17,6 +17,7 @@ use \MCC\Formula\FormulaUnfolder;
 
 const INT_MAX                                 = 9999999;
 
+const SUBCAT_REACHABILITY_SPEC                = "ReachabilitySpec";
 const SUBCAT_REACHABILITY_DEADLOCK            = "ReachabilityDeadlock";
 const SUBCAT_REACHABILITY_FIREABILITY_SIMPLE  = "ReachabilityFireabilitySimple";
 const SUBCAT_REACHABILITY_FIREABILITY         = "ReachabilityFireability";
@@ -89,7 +90,8 @@ class GenerateFormulas extends Base
   </property>
 EOT;
   private $all_subcategories = array (
-        SUBCAT_REACHABILITY_DEADLOCK
+        SUBCAT_REACHABILITY_SPEC
+      , SUBCAT_REACHABILITY_DEADLOCK
       , SUBCAT_REACHABILITY_FIREABILITY_SIMPLE
       , SUBCAT_REACHABILITY_FIREABILITY
       , SUBCAT_REACHABILITY_CARDINALITY
@@ -271,6 +273,7 @@ EOT;
     case SUBCAT_LTL_CARDINALITY :
       return $this->filter_out_formulas_smt ($formulas);
 
+    case SUBCAT_REACHABILITY_SPEC :
     case SUBCAT_REACHABILITY_FIREABILITY :
     case SUBCAT_REACHABILITY_CARDINALITY :
     case SUBCAT_LTL_FIREABILITY_SIMPLE :
@@ -425,8 +428,22 @@ EOT;
     $tmp1               = new Symbol ("tmp-formula1");
     $tmp2               = new Symbol ("tmp-formula2");
 
+    //print ("\n" . $subcategory . "=> " . $subcategory . "\n");
     switch ($subcategory)
     {
+    case $subcategory :
+      $g = new Grammar ($this, $boolean_formula);
+      $g->add_rule (new Rule ($boolean_formula, array ($exists,   $tmp1)));
+      $g->add_rule (new Rule ($tmp1,            array ($finally,  $state_formula)));
+
+      $g->add_rule (new Rule ($state_formula,   array ($and,      $state_formula, $state_formula)));
+      $g->add_rule (new Rule ($state_formula,   array ($or,       $state_formula, $state_formula)));
+      $g->add_rule (new Rule ($state_formula,     array ($is_fireable)));
+      $g->add_rule (new Rule ($state_formula,     array ($leq,      $integer_expression, $tokens_count)));
+      $g->add_rule (new Rule ($integer_expression, array ($integer_constant)));
+      $g->add_rule (new Rule ($integer_expression, array ($tokens_count)));
+      break;
+
     case SUBCAT_REACHABILITY_DEADLOCK :
       $g = new Grammar ($this, $boolean_formula);
       $g->add_rule (new Rule ($boolean_formula, array ($exists,  $tmp1)));

--- a/src/MCC/Command/GenerateFormulas.php
+++ b/src/MCC/Command/GenerateFormulas.php
@@ -392,6 +392,7 @@ EOT;
     $deadlock         = new Symbol ("deadlock",         "<deadlock/>",     $this, true);
     $is_fireable      = new Symbol ("is-fireable",      null,              $this, true);
     $leq              = new Symbol ("<=",               "<integer-le/>",   $this, true);
+    $eq               = new Symbol ("==",               "<integer-eq/>",   $this, true);
     $integer_constant = new Symbol ("integer-constant", null,              $this, true);
     $place_bound      = new Symbol ("place-bound",      "<place-bound/>",  $this, true);
     $tokens_count     = new Symbol ("tokens-count",     "<tokens-count/>", $this, true);
@@ -406,9 +407,9 @@ EOT;
     $tmp1               = new Symbol ("tmp-formula1");
     $tmp2               = new Symbol ("tmp-formula2");
 
-    //print ("\n" . $subcategory . "=> " . $subcategory . "\n");
+    //print ("\n" . $subcategory . "=> " . SUBCAT_REACHABILITY_SPEC . "\n");
     switch ($subcategory) {
-    case $subcategory :
+    case SUBCAT_REACHABILITY_SPEC :
       $g = new Grammar ($this, $boolean_formula);
       $g->add_rule (new Rule ($boolean_formula, array ($exists,   $tmp1)));
       $g->add_rule (new Rule ($tmp1,            array ($finally,  $state_formula)));
@@ -416,7 +417,8 @@ EOT;
       $g->add_rule (new Rule ($state_formula,   array ($and,      $state_formula, $state_formula)));
       $g->add_rule (new Rule ($state_formula,   array ($or,       $state_formula, $state_formula)));
       $g->add_rule (new Rule ($state_formula,     array ($is_fireable)));
-      $g->add_rule (new Rule ($state_formula,     array ($leq,      $integer_expression, $tokens_count)));
+      $g->add_rule (new Rule ($state_formula,     array ($leq,      $integer_constant, $tokens_count)));
+      $g->add_rule (new Rule ($state_formula,     array ($eq ,      $integer_constant, $tokens_count)));
       $g->add_rule (new Rule ($integer_expression, array ($integer_constant)));
       $g->add_rule (new Rule ($integer_expression, array ($tokens_count)));
       break;

--- a/src/MCC/Command/GenerateFormulas.php
+++ b/src/MCC/Command/GenerateFormulas.php
@@ -144,8 +144,8 @@ EOT;
     else
       $this->model = $this->pt_model;
 
-    if ($this->sn_model) echo "mcc: generate: have COL model: $this->sn_file\n";
-    if ($this->pt_model) echo "mcc: generate: have PT  model: $this->pt_file\n";
+//    if ($this->sn_model) echo "mcc: generate: have COL model: $this->sn_file\n";
+//    if ($this->pt_model) echo "mcc: generate: have PT  model: $this->pt_file\n";
 
     $this->smt_formula_filter = new SmtFormulaFilter ($this->console_output, $this->places);
 
@@ -165,11 +165,11 @@ EOT;
     {
       // hack to avoid memory overflow in this model ...
       $nr = $this->quantity * 7;
-      echo "mcc: HACK on 'TokenRing', reduced number of intermmediate formulas\n";
+//      echo "mcc: HACK on 'TokenRing', reduced number of intermmediate formulas\n";
     }
 
     // generate $nr formulas, store them in the array $formulas[]
-    echo "mcc: generating $nr formulas\n";
+//    echo "mcc: generating $nr formulas\n";
     $formulas = array();
     for ($i = 0; $i < $nr; $i++)
     {
@@ -178,9 +178,9 @@ EOT;
     }
 
     // filter out those of bad quality
-    echo "mcc: generate: filtering out formulas\n";
+//    echo "mcc: generate: filtering out formulas\n";
     $filtered_formulas = $this->filter_out_formulas ($formulas);
-    echo "mcc: generate: after filtering out: got " . count ($filtered_formulas) . " formulas\n";
+//    echo "mcc: generate: after filtering out: got " . count ($filtered_formulas) . " formulas\n";
     assert (count ($filtered_formulas) <= $this->quantity);
 
     // if we were unable to produce $this->quantity formulas, complete with
@@ -200,15 +200,18 @@ EOT;
 
     // save all formulas into one xml file
     $this->save_formulas ($filtered_formulas, $this->output);
-	  echo "mcc: generate: wrote " . count ($filtered_formulas) . " formulas in '$this->output'\n";
+//  echo "mcc: generate: wrote " . count ($filtered_formulas) . " formulas in '$this->output'\n";
 
     // execute, if requested, the 'unfold' and 'to-text' commands
     if ($this->chain)
     {
-      foreach (array(
+      $chained = array(
         'formula:unfold',
         'formula:to-text'
-      ) as $c)
+      );
+      if ($this->subcategory == SUBCAT_REACHABILITY_SPEC)
+        $chained [] = 'formula:to-spec';
+      foreach ($chained as $c)
       {
         $command = $this->getApplication()->find($c);
         $arguments = array(
@@ -226,7 +229,7 @@ EOT;
 
   private function save_formulas ($formulas, $path, $ids = null)
   {
-	  echo "mcc: generate: writing " . count ($formulas) . " formulas to file '$path'\n";
+//  echo "mcc: generate: writing " . count ($formulas) . " formulas to file '$path'\n";
     $xml_tree = $this->load_xml('<property-set xmlns="http://mcc.lip6.fr/"/>');
     for ($i = 0; $i < count ($formulas); $i++)
     {
@@ -291,13 +294,13 @@ EOT;
 
   private function filter_out_formulas_smt ($formulas)
   {
-    echo "mcc: generate: using the SMT filter on " . count ($formulas) . " formulas\n";
+ //   echo "mcc: generate: using the SMT filter on " . count ($formulas) . " formulas\n";
     $result = array ();
     foreach ($formulas as $formula)
     {
       if ($this->smt_formula_filter->filter_out ($formula))
       {
-        echo "mcc: generate:  discarding formula\n";
+//        echo "mcc: generate:  discarding formula\n";
         continue;
       }
 
@@ -318,8 +321,8 @@ EOT;
       if ($this->pt_model)
       {
         // we have a PT equivalent
-        echo "mcc: generate: unfolding COL formulas to PT\n";
-        echo "mcc: generate: " . count ($formulas) . " formulas\n";
+//        echo "mcc: generate: unfolding COL formulas to PT\n";
+//        echo "mcc: generate: " . count ($formulas) . " formulas\n";
         $unfolded_formulas = array ();
         $unfolder = new FormulaUnfolder ($this->sn_model, $this->pt_model);
         foreach ($formulas as $f)
@@ -328,19 +331,19 @@ EOT;
           $unfolder->unfold ($uf);
           $unfolded_formulas[] = $uf;
         }
-        echo "mcc: generate: formulas unfolded\n";
+//        echo "mcc: generate: formulas unfolded\n";
       }
       else
       {
         // we don't have a PT equivalent, we don't filter :(
-        echo "mcc: generate: we don't have a PT equivalent model, no filtering!!!!\n";
+//        echo "mcc: generate: we don't have a PT equivalent model, no filtering!!!!\n";
         return array_slice ($formulas, 0, $this->quantity);
       }
     }
     else
     {
       // we are processing a PT model, nothing to do
-      echo "mcc: generate: this is a PT model, no need to unfold\n";
+//      echo "mcc: generate: this is a PT model, no need to unfold\n";
       assert ($this->pt_model != null);
       $unfolded_formulas = $formulas;
     }
@@ -362,10 +365,10 @@ EOT;
     $cmd .= "grep '^smc: formulas:' $smcout 1>&2; ";
     $cmd .= "grep '^smc: resources:' $smcout 1>&2; ";
 
-    echo "mcc: generate: $cmd\n";
+//    echo "mcc: generate: $cmd\n";
     exec ($cmd, $output, $retval);
-    echo "mcc: generate: cmd returns with status $retval\n";
-    echo "mcc: generate: cmd output contains " . count ($output) . " lines\n";
+//    echo "mcc: generate: cmd returns with status $retval\n";
+//    echo "mcc: generate: cmd output contains " . count ($output) . " lines\n";
 
     // handle execution errors
     if ($retval != 0)

--- a/src/MCC/Command/GenerateSpec.php
+++ b/src/MCC/Command/GenerateSpec.php
@@ -60,6 +60,7 @@ class GenerateSpec extends Base
     foreach ($model->net->page->transition as $transition)
     {
       $id             = (string) $transition->attributes()['id'];
+      $name           = (string) $transition->name->text;
       $preconditions  = array();
       $postconditions = array();
       foreach ($pre [$id] as $arc)
@@ -83,6 +84,7 @@ class GenerateSpec extends Base
           $value = 1;
         $postconditions[] = "\t\t${target}' = ${target} + ${value}";
       }
+      fwrite($fp, "\t# Transition ${id}: ${name}\n");
       fwrite($fp, implode(",\n", $preconditions));
       fwrite($fp, " ->\n");
       fwrite($fp, implode(",\n", $postconditions));

--- a/src/MCC/Command/GenerateSpec.php
+++ b/src/MCC/Command/GenerateSpec.php
@@ -21,9 +21,7 @@ class GenerateSpec extends Base
   protected function perform()
   {
     if ($this->pt_model == NULL)
-    {
       return;
-    }
     $model = $this->pt_model;
     $quantity = count($model->net->page->place) +
       count($model->net->page->transition);
@@ -31,65 +29,69 @@ class GenerateSpec extends Base
     $this->progress->start($this->console_output, $quantity);
     $file  = dirname(realpath($this->pt_file)) . '/model.spec';
     $fp = fopen($file, 'w');
-    
     fwrite($fp, "vars\n");
     fwrite($fp, "\t");
-
     $initmarking = array();
     foreach ($model->net->page->place as $place)
     {
       $id = (string) $place->attributes()['id'];
       fwrite($fp, "${id} ");
-
       $initial = (string) $place->initialMarking->text;
       if (($initial == NULL) || ($initial == ""))
-	{
-	  $initial = 0;
-	}
+        $initial = 0;
       $initmarking[] = "${id} = ${initial}";
       $this->progress->advance();
     }
     fwrite($fp, "\n\n");
     fwrite($fp, "rules\n");
-
+    $pre  = array ();
+    $post = array ();
+    foreach ($model->net->page->arc as $arc)
+    {
+      $source = (string) $arc->attributes()['source'];
+      $target = (string) $arc->attributes()['target'];
+      if (! array_key_exists ($target, $pre ))
+        $pre  [$target] = array ();
+      if (! array_key_exists ($source, $post))
+        $post [$source] = array ();
+      $pre  [$target] [] = $arc;
+      $post [$source] [] = $arc;
+    }
     foreach ($model->net->page->transition as $transition)
     {
-      $id = (string) $transition->attributes()['id'];
-      $name = (string) $transition->name->text;
-
-      $preconditions = array();
+      $id             = (string) $transition->attributes()['id'];
+      $preconditions  = array();
       $postconditions = array();
-      foreach ($model->net->page->arc as $arc)
+      foreach ($pre [$id] as $arc)
       {
         $source = (string) $arc->attributes()['source'];
+        $value  = (string) $arc->inscription->text;
+        if (($value == NULL) || ($value == ""))
+          $value = 1;
+        $preconditions  [] = "\t${source} >= ${value}";
+        $postconditions [] = "\t\t${source}' = ${source} - ${value}";
+      }
+      if (! array_key_exists ($id, $post))
+      {
+        $post [$id] = array ();
+      }
+      foreach ($post [$id] as $arc)
+      {
         $target = (string) $arc->attributes()['target'];
         $value  = (string) $arc->inscription->text;
         if (($value == NULL) || ($value == ""))
-        {
           $value = 1;
-        }
-        if ($target == $id)
-        {
-          $preconditions[] = "\t${source} >= ${value}";
-	  $postconditions[] = "\t\t${source}' = ${source} - ${value}";
-        }
-
-	if ($source == $id)
-	  {
-	    $postconditions[] = "\t\t${target}' = ${target} + ${value}";
-	  }
+        $postconditions[] = "\t\t${target}' = ${target} + ${value}";
       }
       fwrite($fp, implode(",\n", $preconditions));
       fwrite($fp, " ->\n");
       fwrite($fp, implode(",\n", $postconditions));
-      fwrite($fp, ";\n \n");      
-
+      fwrite($fp, ";\n \n");
       $this->progress->advance();
     }
     fwrite($fp, "init\n\t");
     fwrite($fp, implode(", ", $initmarking));
     fwrite($fp, "\n\n");
-
     fclose($fp);
     $this->progress->finish();
   }

--- a/src/MCC/Command/GenerateSpec.php
+++ b/src/MCC/Command/GenerateSpec.php
@@ -1,12 +1,6 @@
 <?php
 namespace MCC\Command;
 
-use \Symfony\Component\Console\Input\InputOption;
-use \Symfony\Component\Console\Input\InputArgument;
-use \Symfony\Component\Console\Input\InputInterface;
-use \Symfony\Component\Console\Output\OutputInterface;
-use \MCC\Command\Base;
-
 class GenerateSpec extends Base
 {
 
@@ -32,8 +26,7 @@ class GenerateSpec extends Base
     fwrite($fp, "vars\n");
     fwrite($fp, "\t");
     $initmarking = array();
-    foreach ($model->net->page->place as $place)
-    {
+    foreach ($model->net->page->place as $place) {
       $id = (string) $place->attributes()['id'];
       fwrite($fp, "${id} ");
       $initial = (string) $place->initialMarking->text;
@@ -46,8 +39,7 @@ class GenerateSpec extends Base
     fwrite($fp, "rules\n");
     $pre  = array ();
     $post = array ();
-    foreach ($model->net->page->arc as $arc)
-    {
+    foreach ($model->net->page->arc as $arc) {
       $source = (string) $arc->attributes()['source'];
       $target = (string) $arc->attributes()['target'];
       if (! isset ($pre [$target]))
@@ -57,14 +49,12 @@ class GenerateSpec extends Base
       $pre  [$target] [] = $arc;
       $post [$source] [] = $arc;
     }
-    foreach ($model->net->page->transition as $transition)
-    {
+    foreach ($model->net->page->transition as $transition) {
       $id             = (string) $transition->attributes()['id'];
       $name           = (string) $transition->name->text;
       $preconditions  = array();
       $postconditions = array();
-      foreach ($pre [$id] as $arc)
-      {
+      foreach ($pre [$id] as $arc) {
         $source = (string) $arc->attributes()['source'];
         $value  = (string) $arc->inscription->text;
         if (($value == NULL) || ($value == ""))
@@ -72,12 +62,10 @@ class GenerateSpec extends Base
         $preconditions  [] = "\t${source} >= ${value}";
         $postconditions [] = "\t\t${source}' = ${source} - ${value}";
       }
-      if (! isset ($post [$id]))
-      {
+      if (! isset ($post [$id])) {
         $post [$id] = array ();
       }
-      foreach ($post [$id] as $arc)
-      {
+      foreach ($post [$id] as $arc) {
         $target = (string) $arc->attributes()['target'];
         $value  = (string) $arc->inscription->text;
         if (($value == NULL) || ($value == ""))

--- a/src/MCC/Command/GenerateSpec.php
+++ b/src/MCC/Command/GenerateSpec.php
@@ -50,9 +50,9 @@ class GenerateSpec extends Base
     {
       $source = (string) $arc->attributes()['source'];
       $target = (string) $arc->attributes()['target'];
-      if (! array_key_exists ($target, $pre ))
+      if (! isset ($pre [$target]))
         $pre  [$target] = array ();
-      if (! array_key_exists ($source, $post))
+      if (! isset ($post [$source]))
         $post [$source] = array ();
       $pre  [$target] [] = $arc;
       $post [$source] [] = $arc;
@@ -72,7 +72,7 @@ class GenerateSpec extends Base
         $preconditions  [] = "\t${source} >= ${value}";
         $postconditions [] = "\t\t${source}' = ${source} - ${value}";
       }
-      if (! array_key_exists ($id, $post))
+      if (! isset ($post [$id]))
       {
         $post [$id] = array ();
       }

--- a/src/MCC/Command/Import.php
+++ b/src/MCC/Command/Import.php
@@ -4,13 +4,14 @@ namespace MCC\Command;
 use \Symfony\Component\Console\Command\Command;
 use \Symfony\Component\Console\Input\InputArgument;
 use \Symfony\Component\Console\Input\InputInterface;
-use \Symfony\Component\Console\Input\InputOption;
 use \Symfony\Component\Console\Output\OutputInterface;
 use \MCC\Import\CSV2013;
 use \Doctrine\ORM\Tools\SchemaTool;
 
-class Import extends Command {
-  protected function configure() {
+class Import extends Command
+{
+  protected function configure()
+  {
     $this -> setName('import')
           -> setDescription('Import data.')
           -> addArgument('year', InputArgument::REQUIRED, 'Edition of the MCC?')
@@ -26,7 +27,8 @@ EOF
              );
   }
 
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output)
+  {
     $this -> generateDatabase($input, $output);
     $year = $input -> getArgument('year');
     $resultsdir = $input -> getArgument('directory');
@@ -38,7 +40,8 @@ EOF
     }
   }
 
-  protected function generateDatabase(InputInterface $input, OutputInterface $output) {
+  protected function generateDatabase(InputInterface $input, OutputInterface $output)
+  {
     global $entityManager;
     $classes = array(
       $entityManager -> getClassMetadata('\MCC\Data\Contest'),

--- a/src/MCC/Command/ModelInfo.php
+++ b/src/MCC/Command/ModelInfo.php
@@ -1,10 +1,6 @@
 <?php
 namespace MCC\Command;
 
-use \Symfony\Component\Console\Input\InputInterface;
-use \Symfony\Component\Console\Output\OutputInterface;
-use \MCC\Command\Base;
-
 class ModelInfo extends Base
 {
 
@@ -18,20 +14,14 @@ class ModelInfo extends Base
 
   protected function perform()
   {
-    if ($this->sn_model && $this->pt_model)
-    {
+    if ($this->sn_model && $this->pt_model) {
       $this->console_output->writeln("Colored with P/T equivalent");
-    }
-    else if ($this->sn_model && ! $this->pt_model)
-    {
+    } elseif ($this->sn_model && ! $this->pt_model) {
       $this->console_output->writeln("Colored only");
-    }
-    else if (! $this->sn_model && $this->pt_model)
-    {
+    } elseif (! $this->sn_model && $this->pt_model) {
       $this->console_output->writeln("P/T only");
     }
-    if ($this->sn_model)
-    {
+    if ($this->sn_model) {
       $this->console_output->writeln("# Colored places: " .
         count($this->sn_model->net->page->place));
       $this->console_output->writeln("# Colored transitions: " .
@@ -39,8 +29,7 @@ class ModelInfo extends Base
       $this->console_output->writeln("# Colored arcs: " .
         count($this->sn_model->net->page->arc));
     }
-    if ($this->pt_model)
-    {
+    if ($this->pt_model) {
       $this->console_output->writeln("# P/T places: " .
         count($this->pt_model->net->page->place));
       $this->console_output->writeln("# P/T transitions: " .

--- a/src/MCC/Command/Show.php
+++ b/src/MCC/Command/Show.php
@@ -9,14 +9,13 @@ use \MCC\Data\Instance;
 use \MCC\Data\Model;
 use \MCC\Data\Tool;
 use \Symfony\Component\Console\Command\Command;
-use \Symfony\Component\Console\Input\InputArgument;
 use \Symfony\Component\Console\Input\InputInterface;
-use \Symfony\Component\Console\Input\InputOption;
 use \Symfony\Component\Console\Output\OutputInterface;
-use \Symfony\Component\Console\Helper\FormatterHelper;
 
-class Show extends Command {
-  protected function configure() {
+class Show extends Command
+{
+  protected function configure()
+  {
     $this -> setName('show')
           -> setDescription('Shows the data.')
           -> setHelp(<<<EOF
@@ -26,7 +25,8 @@ EOF
              );
   }
 
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output)
+  {
     global $entityManager;
     $formatter = $this->getHelperSet()->get('formatter');
 
@@ -49,7 +49,7 @@ EOF
     foreach ($tools as $tool) {
       echo "  {$tool}\n";
     }
-    
+
     $models = $entityManager -> getRepository('\MCC\Data\Model') -> findAll();
     $formattedLine = $formatter->formatSection(
       'Models',
@@ -59,7 +59,7 @@ EOF
     foreach ($models as $model) {
       echo "  {$model}\n";
     }
-    
+
     $instances = $entityManager -> getRepository('\MCC\Data\Instance') -> findAll();
     $formattedLine = $formatter->formatSection(
       'Instances',
@@ -69,7 +69,7 @@ EOF
     foreach ($instances as $instance) {
       echo "  {$instance}\n";
     }
-    
+
     $contests = $entityManager -> getRepository('\MCC\Data\Contest') -> findAll();
     $formattedLine = $formatter->formatSection(
       'Contests',
@@ -79,7 +79,7 @@ EOF
     foreach ($contests as $contest) {
       echo "  {$contest}\n";
     }
-    
+
     $examinations = $entityManager -> getRepository('\MCC\Data\Examination') -> findAll();
     $formattedLine = $formatter->formatSection(
       'Examinations',

--- a/src/MCC/Command/Statistics.php
+++ b/src/MCC/Command/Statistics.php
@@ -9,14 +9,13 @@ use \MCC\Data\Instance;
 use \MCC\Data\Model;
 use \MCC\Data\Tool;
 use \Symfony\Component\Console\Command\Command;
-use \Symfony\Component\Console\Input\InputArgument;
 use \Symfony\Component\Console\Input\InputInterface;
-use \Symfony\Component\Console\Input\InputOption;
 use \Symfony\Component\Console\Output\OutputInterface;
-use \Symfony\Component\Console\Helper\FormatterHelper;
 
-class Statistics extends Command {
-  protected function configure() {
+class Statistics extends Command
+{
+  protected function configure()
+  {
     $this -> setName('statistics')
           -> setDescription('Statistics about the data.')
           -> setHelp(<<<EOF
@@ -26,7 +25,8 @@ EOF
              );
   }
 
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output)
+  {
     global $entityManager;
     $formatter = $this->getHelperSet()->get('formatter');
 
@@ -43,28 +43,28 @@ EOF
       'Count: ' . count($tools)
     );
     $output->writeln($formattedLine);
-    
+
     $models = $entityManager -> getRepository('\MCC\Data\Model') -> findAll();
     $formattedLine = $formatter->formatSection(
       'Models',
       'Count: ' . count($models)
     );
     $output->writeln($formattedLine);
-    
+
     $instances = $entityManager -> getRepository('\MCC\Data\Instance') -> findAll();
     $formattedLine = $formatter->formatSection(
       'Instances',
       'Count: ' . count($instances)
     );
     $output->writeln($formattedLine);
-    
+
     $contests = $entityManager -> getRepository('\MCC\Data\Contest') -> findAll();
     $formattedLine = $formatter->formatSection(
       'Contests',
       'Count: ' . count($contests)
     );
     $output->writeln($formattedLine);
-    
+
     $examinations = $entityManager -> getRepository('\MCC\Data\Examination') -> findAll();
     $formattedLine = $formatter->formatSection(
       'Examinations',
@@ -74,4 +74,3 @@ EOF
   }
 
 }
-

--- a/src/MCC/Command/ToCami.php
+++ b/src/MCC/Command/ToCami.php
@@ -4,7 +4,6 @@ namespace MCC\Command;
 use \Symfony\Component\Console\Input\InputOption;
 use \Symfony\Component\Console\Input\InputInterface;
 use \Symfony\Component\Console\Output\OutputInterface;
-use \MCC\Command\Base;
 
 class ToCami extends Base
 {
@@ -39,14 +38,12 @@ class ToCami extends Base
     $cami_id = 1;
     $equivalence = array();
     $file = fopen(preg_replace('/.pnml$/', '.cami', $this->pt_file), 'w');
-    if ($this->wrap)
-    {
+    if ($this->wrap) {
       fwrite($file, "DB()\n");
     }
     fwrite($file, "CN(3:net,${cami_id})\n");
     $cami_id++;
-    foreach ($model->net->page->place as $place)
-    {
+    foreach ($model->net->page->place as $place) {
       $id      = (string) $place->attributes()['id'];
       $name    = (string) $place->name->text;
       $marking = (string) $place->initialMarking->text;
@@ -62,8 +59,7 @@ class ToCami extends Base
       $cami_id++;
       $this->progress->advance();
     }
-    foreach ($model->net->page->transition as $transition)
-    {
+    foreach ($model->net->page->transition as $transition) {
       $id   = (string) $transition->attributes()['id'];
       $name = (string) $transition->name->text;
       $id_length = strlen($id);
@@ -73,8 +69,7 @@ class ToCami extends Base
       $cami_id++;
       $this->progress->advance();
     }
-    foreach ($model->net->page->arc as $arc)
-    {
+    foreach ($model->net->page->arc as $arc) {
       $id        = (string) $arc->attributes()['id'];
       $source    = (string) $arc->attributes()['source'];
       $target    = (string) $arc->attributes()['target'];
@@ -91,13 +86,11 @@ class ToCami extends Base
       $cami_id++;
       $this->progress->advance();
     }
-    if ($this->wrap)
-    {
+    if ($this->wrap) {
       fwrite($file, "FB()\n");
     }
     fclose($file);
     $this->progress->finish();
   }
 
-
-} 
+}

--- a/src/MCC/Command/ToCosy.php
+++ b/src/MCC/Command/ToCosy.php
@@ -1,11 +1,6 @@
 <?php
 namespace MCC\Command;
 
-use \Symfony\Component\Console\Input\InputOption;
-use \Symfony\Component\Console\Input\InputInterface;
-use \Symfony\Component\Console\Output\OutputInterface;
-use \MCC\Command\Base;
-
 class ToCosy extends Base
 {
 
@@ -42,8 +37,7 @@ class ToCosy extends Base
     fwrite($file, "model.transition = {}\n");
     fwrite($file, "model.arc        = { pre = {}, post = {} }\n");
     fwrite($file, "\n");
-    foreach ($model->net->page->place as $place)
-    {
+    foreach ($model->net->page->place as $place) {
       $id      = (string) $place->attributes()['id'];
       $name    = (string) $place->name->text;
       $marking = (string) $place->initialMarking->text;
@@ -59,8 +53,7 @@ class ToCosy extends Base
       fwrite($file, "end\n");
       $this->progress->advance();
     }
-    foreach ($model->net->page->transition as $transition)
-    {
+    foreach ($model->net->page->transition as $transition) {
       $id   = (string) $transition->attributes()['id'];
       $name = (string) $transition->name->text;
       fwrite($file, "do\n");
@@ -71,8 +64,7 @@ class ToCosy extends Base
       fwrite($file, "end\n");
       $this->progress->advance();
     }
-    foreach ($model->net->page->arc as $arc)
-    {
+    foreach ($model->net->page->arc as $arc) {
       $id        = (string) $arc->attributes()['id'];
       $source    = (string) $arc->attributes()['source'];
       $target    = (string) $arc->attributes()['target'];
@@ -95,5 +87,4 @@ class ToCosy extends Base
     $this->progress->finish();
   }
 
-
-} 
+}

--- a/src/MCC/Command/UnfoldFormulas.php
+++ b/src/MCC/Command/UnfoldFormulas.php
@@ -4,8 +4,6 @@ namespace MCC\Command;
 use \Symfony\Component\Console\Input\InputInterface;
 use \Symfony\Component\Console\Output\OutputInterface;
 use \Symfony\Component\Console\Input\InputOption;
-use \MCC\Command\Base;
-use \MCC\Formula\EquivalentElements;
 use \MCC\Formula\FormulaUnfolder;
 
 class UnfoldFormulas extends Base
@@ -29,8 +27,7 @@ class UnfoldFormulas extends Base
 
   protected function pre_perform(InputInterface $input, OutputInterface $output)
   {
-    if (($this->sn_model == null) || ($this->pt_model == null))
-    {
+    if (($this->sn_model == null) || ($this->pt_model == null)) {
       return;
     }
     $input_path = dirname($this->sn_file);
@@ -41,8 +38,7 @@ class UnfoldFormulas extends Base
 
   protected function perform()
   {
-    if (($this->sn_model == null) || ($this->pt_model == null))
-    {
+    if (($this->sn_model == null) || ($this->pt_model == null)) {
       return;
     }
 
@@ -54,8 +50,7 @@ class UnfoldFormulas extends Base
     $quantity = count($xml->children());
     $this->progress->setRedrawFrequency(max(1, $quantity / 100));
     $this->progress->start($this->console_output, $quantity);
-    foreach ($xml->property as $property)
-    {
+    foreach ($xml->property as $property) {
       $unfolder->unfold ($property->formula->children()[0]);
       $this->progress->advance();
     }

--- a/src/MCC/Data/Contest.php
+++ b/src/MCC/Data/Contest.php
@@ -9,8 +9,8 @@ use \Doctrine\Common\Collections\ArrayCollection;
  * @Entity
  * @Table(name="Contest")
  */
-class Contest {
-
+class Contest
+{
   /**
    * @Id
    * @GeneratedValue
@@ -49,7 +49,8 @@ class Contest {
    */
   protected $examinations;
 
-  public function __construct($edition) {
+  public function __construct($edition)
+  {
     global $entityManager;
     $entityManager -> persist($this);
     $this -> edition = $edition;
@@ -60,27 +61,31 @@ class Contest {
     $this -> examinations = new ArrayCollection();
   }
 
-  public function __toString() {
+  public function __toString()
+  {
     return "mcc {$this->edition}";
   }
 
-  public function add($value) {
+  public function add($value)
+  {
     if (get_class($value) == "MCC\Data\Examination") {
       $this -> examinations -> add($value);
       $value -> setContest($this);
-    } else if (get_class($value) == "MCC\Data\Instance") {
+    } elseif (get_class($value) == "MCC\Data\Instance") {
       $this -> instances -> add($value);
-    } else if (get_class($value) == "MCC\Data\Model") {
+    } elseif (get_class($value) == "MCC\Data\Model") {
       $this -> models -> add($value);
-    } else if (get_class($value) == "MCC\Data\Tool") {
+    } elseif (get_class($value) == "MCC\Data\Tool") {
       $this -> tools -> add($value);
     } else {
       throw new Exception("");
     }
+
     return $this;
   }
 
-  public function __get($property) {
+  public function __get($property)
+  {
     if (property_exists($this, $property)) {
       return $this -> $property;
     }

--- a/src/MCC/Data/Examination.php
+++ b/src/MCC/Data/Examination.php
@@ -2,17 +2,14 @@
 
 namespace MCC\Data;
 
-use \MCC\Data\Instance;
-use \MCC\Data\Tool;
-use \Doctrine\Common\Collections\Collection;
 use \Doctrine\Common\Collections\ArrayCollection;
 
 /**
  * @Entity
  * @Table(name="Examination")
  */
-class Examination {
-
+class Examination
+{
   /**
    * @Id
    * @GeneratedValue
@@ -106,7 +103,8 @@ class Examination {
    */
   protected $contest = null;
 
-  public function __construct(Tool $tool, Instance $instance) {
+  public function __construct(Tool $tool, Instance $instance)
+  {
     global $entityManager;
     $entityManager -> persist($this);
     $this -> tool = $tool;
@@ -114,7 +112,8 @@ class Examination {
     $this -> result = new ArrayCollection();
   }
 
-  public function __toString() {
+  public function __toString()
+  {
     $tags = '';
     if ($this -> isStateSpace) {
       $tags = $tags . ' state-space';
@@ -143,87 +142,111 @@ class Examination {
     if ($this -> hasPlaceComparison) {
       $tags = $tags . ' place';
     }
+
     return "{$this->tool} on {$this->instance} (tags:{$tags}): {$this->result} [{$this->time}s/{$this->cpu}s/{$this->memory}%]";
   }
 
-  public function setStateSpace() {
+  public function setStateSpace()
+  {
     $this -> isStateSpace = true;
     $this -> isReachability = false;
     $this -> isCTL = false;
     $this -> isLTL = false;
+
     return $this;
   }
 
-  public function setReachability() {
+  public function setReachability()
+  {
     $this -> isStateSpace = false;
     $this -> isReachability = true;
     $this -> isCTL = false;
     $this -> isLTL = false;
+
     return $this;
   }
 
-  public function setCTL() {
+  public function setCTL()
+  {
     $this -> isStateSpace = false;
     $this -> isReachability = false;
     $this -> isCTL = true;
     $this -> isLTL = false;
+
     return $this;
   }
 
-  public function setLTL() {
+  public function setLTL()
+  {
     $this -> isStateSpace = false;
     $this -> isReachability = false;
     $this -> isCTL = false;
     $this -> isLTL = true;
+
     return $this;
   }
 
-  public function setDeadlock() {
+  public function setDeadlock()
+  {
     $this -> hasDeadlock = true;
+
     return $this;
   }
 
-  public function setFireability() {
+  public function setFireability()
+  {
     $this -> hasFireability = true;
+
     return $this;
   }
 
-  public function setCardinalityComparison() {
+  public function setCardinalityComparison()
+  {
     $this -> hasCardinalityComparison = true;
+
     return $this;
   }
 
-  public function setMarkingComparison() {
+  public function setMarkingComparison()
+  {
     $this -> hasMarkingComparison = true;
+
     return $this;
   }
 
-  public function setPlaceComparison() {
+  public function setPlaceComparison()
+  {
     $this -> hasPlaceComparison = true;
+
     return $this;
   }
 
-  public function setResult($value) {
+  public function setResult($value)
+  {
     $this -> result = $value;
+
     return $this;
   }
 
-  public function setContest($contest) {
+  public function setContest($contest)
+  {
     $this -> contest = $contest;
+
     return $this;
   }
 
-  public function result() {
+  public function result()
+  {
     if ($this -> isStateSpace) {
       return floatval($this -> result);
-    } else if ($this -> isReachability || $this -> isCTL || $this -> isLTL) {
+    } elseif ($this -> isReachability || $this -> isCTL || $this -> isLTL) {
       $res = array();
       for ($i = 0; $i < strlen($this -> result); $i++) {
         if ($this -> result[$i] == 'T') {
           $res[] = true;
-        } else if ($this -> result[$i] == 'F') {
+        } elseif ($this -> result[$i] == 'F') {
           $res[] = false;
-        } else if ($this -> result[$i] == '-') {
+        } elseif ($this -> result[$i] == '-') {
           $res[] = null;
         } else {
           throw new Exception("Character representing result {$i} of examination {$this} is not 'T', 'F' or '-'.");
@@ -232,23 +255,30 @@ class Examination {
     }
   }
 
-  public function setTime($value) {
+  public function setTime($value)
+  {
     $this -> time = floatval($value);
+
     return $this;
   }
 
-  public function setCPU($value) {
+  public function setCPU($value)
+  {
     $this -> cpu = floatval($value);
+
     return $this;
   }
 
-  public function setMemory($value) {
+  public function setMemory($value)
+  {
     $value = str_replace('%', '', $value);
     $this -> memory = floatval($value) * 100;
+
     return $this;
   }
 
-  public function __get($property) {
+  public function __get($property)
+  {
     if (property_exists($this, $property)) {
       return $this -> $property;
     }

--- a/src/MCC/Data/Formalism.php
+++ b/src/MCC/Data/Formalism.php
@@ -6,8 +6,8 @@ namespace MCC\Data;
  * @Entity
  * @Table(name="Formalism")
  */
-class Formalism {
-
+class Formalism
+{
   /**
    * @Id
    * @GeneratedValue
@@ -22,17 +22,20 @@ class Formalism {
    */
   protected $acronym;
 
-  public function __construct($acronym) {
+  public function __construct($acronym)
+  {
     global $entityManager;
     $entityManager -> persist($this);
     $this -> acronym = $acronym;
   }
 
-  public function __toString() {
+  public function __toString()
+  {
     return "{$this->acronym}";
   }
 
-  public function __get($property) {
+  public function __get($property)
+  {
     if (property_exists($this, $property)) {
       return $this -> $property;
     }

--- a/src/MCC/Data/Instance.php
+++ b/src/MCC/Data/Instance.php
@@ -2,15 +2,12 @@
 
 namespace MCC\Data;
 
-use \MCC\Data\Formalism;
-use \MCC\Data\Model;
-
 /**
  * @Entity
  * @Table(name="Instance")
  */
-class Instance {
-
+class Instance
+{
   /**
    * @Id
    * @GeneratedValue
@@ -37,7 +34,8 @@ class Instance {
    */
   protected $parameter;
 
-  public function __construct(Model $model, Formalism $formalism, $parameter) {
+  public function __construct(Model $model, Formalism $formalism, $parameter)
+  {
     global $entityManager;
     $entityManager -> persist($this);
     $this -> model = $model;
@@ -46,11 +44,13 @@ class Instance {
     $this -> model -> instances -> add($this);
   }
 
-  public function __toString() {
+  public function __toString()
+  {
     return "{$this->model->name}-{$this->formalism}-{$this->parameter}";
   }
 
-  public function __get($property) {
+  public function __get($property)
+  {
     if (property_exists($this, $property)) {
       return $this -> $property;
     }

--- a/src/MCC/Data/Model.php
+++ b/src/MCC/Data/Model.php
@@ -9,8 +9,8 @@ use \Doctrine\Common\Collections\ArrayCollection;
  * @Entity
  * @Table(name="Model")
  */
-class Model {
-
+class Model
+{
   /**
    * @Id
    * @GeneratedValue
@@ -37,28 +37,33 @@ class Model {
    */
   protected $instances;
 
-  public function __construct($name) {
+  public function __construct($name)
+  {
     global $entityManager;
     $entityManager -> persist($this);
     $this -> name = $name;
     $this -> instances = new ArrayCollection();
   }
 
-  public function __toString() {
+  public function __toString()
+  {
     return "{$this->name}";
   }
 
-  public function setColor($color) {
+  public function setColor($color)
+  {
     $this -> color = $color;
   }
 
-  public function __get($property) {
+  public function __get($property)
+  {
     if (property_exists($this, $property)) {
       return $this -> $property;
     }
   }
 
-  public function instance($parameter, Formalism $formalism) {
+  public function instance($parameter, Formalism $formalism)
+  {
     foreach ($instances as $instance) {
       if (($instance -> parameter == $parameter) && ($instance -> formalism == $formalism)) {
         return $instance;

--- a/src/MCC/Data/Tool.php
+++ b/src/MCC/Data/Tool.php
@@ -6,8 +6,8 @@ namespace MCC\Data;
  * @Entity
  * @Table(name="Tool")
  */
-class Tool {
-
+class Tool
+{
   /**
    * @Id
    * @GeneratedValue
@@ -28,21 +28,25 @@ class Tool {
    */
   protected $color = 'black';
 
-  public function __construct($name) {
+  public function __construct($name)
+  {
     global $entityManager;
     $entityManager -> persist($this);
     $this -> name = $name;
   }
 
-  public function __toString() {
+  public function __toString()
+  {
     return "{$this->name}";
   }
 
-  public function setColor($color) {
+  public function setColor($color)
+  {
     $this -> color = $color;
   }
 
-  public function __get($property) {
+  public function __get($property)
+  {
     if (property_exists($this, $property)) {
       return $this -> $property;
     }

--- a/src/MCC/Formula/AtomicPropositions.php
+++ b/src/MCC/Formula/AtomicPropositions.php
@@ -1,9 +1,8 @@
 <?php
 namespace MCC\Formula;
 
-
-class AtomicPropositions {
-
+class AtomicPropositions
+{
   public $cmodel;
   public $umodel;
 
@@ -18,14 +17,13 @@ class AtomicPropositions {
   {
     $result = new Formula();
     $xml = '<deadlock />';
-    if ($this->cmodel)
-    {
+    if ($this->cmodel) {
       $result->sn = new \SimpleXMLElement($xml);
     }
-    if ($this->umodel)
-    {
+    if ($this->umodel) {
       $result->pt = new \SimpleXMLElement($xml);
     }
+
     return $result;
   }
 
@@ -35,31 +33,24 @@ class AtomicPropositions {
     $xml = "<is-live><level>{$level}</level><is-live/>";
     $ref_model = $this->cmodel ? $this->cmodel : $this->umodel;
     $ref_result = new \SimpleXMLElement($xml);
-    foreach ($transitions as $transition)
-    {
+    foreach ($transitions as $transition) {
       $ref_result->addChild('transition', $transition->id);
     }
-    if ($this->cmodel && $this->umodel)
-    {
+    if ($this->cmodel && $this->umodel) {
       $u_result = new \SimpleXMLElement($xml);
-      foreach ($transitions as $ctransition)
-      {
-        foreach ($ctransition->unfolded as $utransition)
-        {
+      foreach ($transitions as $ctransition) {
+        foreach ($ctransition->unfolded as $utransition) {
           $u_result->addChild('transition', $utransition->id);
         }
       }
       $result->sn = $ref_result;
       $result->pt = $u_result;
-    }
-    else if ($this->cmodel)
-    {
+    } elseif ($this->cmodel) {
       $result->sn = $ref_result;
-    }
-    else if ($this->umodel)
-    {
+    } elseif ($this->umodel) {
       $result->pt = $ref_result;
     }
+
     return $result;
   }
 
@@ -69,31 +60,24 @@ class AtomicPropositions {
     $xml = '<is-fireable><is-fireable/>';
     $ref_model = $this->cmodel ? $this->cmodel : $this->umodel;
     $ref_result = new \SimpleXMLElement($xml);
-    foreach ($transitions as $transition)
-    {
+    foreach ($transitions as $transition) {
       $ref_result->addChild('transition', $transition->id);
     }
-    if ($this->cmodel && $this->umodel)
-    {
+    if ($this->cmodel && $this->umodel) {
       $u_result = new \SimpleXMLElement($xml);
-      foreach ($transitions as $ctransition)
-      {
-        foreach ($ctransition->unfolded as $utransition)
-        {
+      foreach ($transitions as $ctransition) {
+        foreach ($ctransition->unfolded as $utransition) {
           $u_result->addChild('transition', $utransition->id);
         }
       }
       $result->sn = $ref_result;
       $result->pt = $u_result;
-    }
-    else if ($this->cmodel)
-    {
+    } elseif ($this->cmodel) {
       $result->sn = $ref_result;
-    }
-    else if ($this->umodel)
-    {
+    } elseif ($this->umodel) {
       $result->pt = $ref_result;
     }
+
     return $result;
   }
 
@@ -103,31 +87,24 @@ class AtomicPropositions {
     $xml = '<place-bound></place-bound>';
     $ref_model = $this->cmodel ? $this->cmodel : $this->umodel;
     $ref_result = new \SimpleXMLElement($xml);
-    foreach ($places as $place)
-    {
+    foreach ($places as $place) {
       $ref_result->addChild('place', $place->id);
     }
-    if ($this->cmodel && $this->umodel)
-    {
+    if ($this->cmodel && $this->umodel) {
       $u_result = new \SimpleXMLElement($xml);
-      foreach ($places as $cplace)
-      {
-        foreach ($cplace->unfolded as $uplace)
-        {
+      foreach ($places as $cplace) {
+        foreach ($cplace->unfolded as $uplace) {
           $u_result->addChild('place', $uplace->id);
         }
       }
       $result->sn = $ref_result;
       $result->pt = $u_result;
-    }
-    else if ($this->cmodel)
-    {
+    } elseif ($this->cmodel) {
       $result->sn = $ref_result;
-    }
-    else if ($this->umodel)
-    {
+    } elseif ($this->umodel) {
       $result->pt = $ref_result;
     }
+
     return $result;
   }
 
@@ -137,31 +114,24 @@ class AtomicPropositions {
     $xml = '<cardinality><tokens></tokens></cardinality>';
     $ref_model = $this->cmodel ? $this->cmodel : $this->umodel;
     $ref_result = new \SimpleXMLElement($xml);
-    foreach ($places as $place)
-    {
+    foreach ($places as $place) {
       $ref_result->tokens->addChild('place', $place->id);
     }
-    if ($this->cmodel && $this->umodel)
-    {
+    if ($this->cmodel && $this->umodel) {
       $u_result = new \SimpleXMLElement($xml);
-      foreach ($places as $cplace)
-      {
-        foreach ($cplace->unfolded as $uplace)
-        {
+      foreach ($places as $cplace) {
+        foreach ($cplace->unfolded as $uplace) {
           $u_result->tokens->addChild('place', $uplace->id);
         }
       }
       $result->sn = $ref_result;
       $result->pt = $u_result;
-    }
-    else if ($this->cmodel)
-    {
+    } elseif ($this->cmodel) {
       $result->sn = $ref_result;
-    }
-    else if ($this->umodel)
-    {
+    } elseif ($this->umodel) {
       $result->pt = $ref_result;
     }
+
     return $result;
   }
 }

--- a/src/MCC/Formula/EquivalentElements.php
+++ b/src/MCC/Formula/EquivalentElements.php
@@ -1,10 +1,6 @@
 <?php
 namespace MCC\Formula;
 
-use \MCC\Formula\Domain;
-use \MCC\Formula\Place;
-use \MCC\Formula\Transition;
-
 class EquivalentElements
 {
   public $cmodel;
@@ -20,13 +16,10 @@ class EquivalentElements
   {
     $this->cmodel = $cmodel;
     $this->umodel = $umodel;
-    if ($this->cmodel)
-    {
+    if ($this->cmodel) {
       $this->sn_places();
       $this->sn_transitions();
-    }
-    else
-    {
+    } else {
       $this->pt_places();
       $this->pt_transitions();
     }
@@ -35,37 +28,29 @@ class EquivalentElements
   private function sn_places()
   {
     // Load colored domains:
-    foreach ($this->cmodel->net->declaration->structure->declarations->namedsort as $sort)
-    {
+    foreach ($this->cmodel->net->declaration->structure->declarations->namedsort as $sort) {
       $id = (string) $sort->attributes()['id'];
       $name = (string) $sort->attributes()['name'];
       $domain = new Domain();
       $domain->id = $id;
       $domain->name = $name;
-      if ($sort->cyclicenumeration)
-      {
+      if ($sort->cyclicenumeration) {
         $domain->values[$id] = array();
-        foreach ($sort->cyclicenumeration->feconstant as $value)
-        {
+        foreach ($sort->cyclicenumeration->feconstant as $value) {
           $vid = (string) $value->attributes()['id'];
           $vname = (string) $value->attributes()['name'];
           $domain->values[$id][$vid] = $vname;
         }
-      }
-      else if ($sort->finiteenumeration)
-      {
+      } elseif ($sort->finiteenumeration) {
         $domain->values[$id] = array();
-        foreach ($sort->finiteenumeration->feconstant as $value)
-        {
+        foreach ($sort->finiteenumeration->feconstant as $value) {
           $vid = (string) $value->attributes()['id'];
           $vname = (string) $value->attributes()['name'];
           $domain->values[$id][$vid] = $vname;
         }
-      } else if ($sort->productsort)
-      {
+      } elseif ($sort->productsort) {
         $i = 0;
-        foreach ($sort->productsort->usersort as $sub)
-        {
+        foreach ($sort->productsort->usersort as $sub) {
           $subname = (string) $sub->attributes()['declaration'];
           $domain->values[$i] = $subname;
           $i += 1;
@@ -74,19 +59,15 @@ class EquivalentElements
       $this->domains[$id] = $domain;
     }
     // When all domains are declared, fill the products:
-    foreach ($this->domains as $domain)
-    {
-      foreach ($domain->values as $k => $v)
-      {
-        if (gettype($v) == 'string')
-        {
+    foreach ($this->domains as $domain) {
+      foreach ($domain->values as $k => $v) {
+        if (gettype($v) == 'string') {
           $domain->values[$k] = $this->domains[$v]->values[$v];
         }
       }
     }
     // Load colored domains and places:
-    foreach ($this->cmodel->net->page->place as $place)
-    {
+    foreach ($this->cmodel->net->page->place as $place) {
       $id = (string) $place->attributes()['id'];
       $name = (string) $place->name->text;
       $domain = (string) $place->type->structure->usersort->attributes()['declaration'];
@@ -96,11 +77,9 @@ class EquivalentElements
       $cplace->domain = $this->domains[$domain];
       $this->cplaces[$id] = $cplace;
     }
-    if ($this->umodel)
-    {
+    if ($this->umodel) {
       // Load unfolded places:
-      foreach ($this->umodel->net->page->place as $place)
-      {
+      foreach ($this->umodel->net->page->place as $place) {
         $id = (string) $place->attributes()['id'];
         $name = (string) $place->name->text;
         $uplace = new Place();
@@ -109,29 +88,21 @@ class EquivalentElements
         $this->uplaces[$id] = $uplace;
       }
       // For each colored place, build regex that recognize its unfoldings:
-      foreach ($this->cplaces as $place)
-      {
+      foreach ($this->cplaces as $place) {
         $size = 1;
         $p = '';
-        foreach ($place->domain->values as $k => $v)
-        {
+        foreach ($place->domain->values as $k => $v) {
           $size *= count($v);
           $first = true;
           $p .= '_(';
           // Warning: here we do an approximation to save a lot of time:
-          if ((count($v) > 100) && (is_numeric(reset($v))))
-          {
+          if ((count($v) > 100) && (is_numeric(reset($v)))) {
             $p .= '[0-9]+';
-          }
-          else
-          {
-            foreach ($v as $vid => $vname)
-            {
-              if ($first)
-              {
+          } else {
+            foreach ($v as $vid => $vname) {
+              if ($first) {
                 $first = false;
-              } else
-              {
+              } else {
                 $p .= '|';
               }
                 $p .= $vname;
@@ -141,27 +112,22 @@ class EquivalentElements
         }
         $regex = "^{$place->name}{$p}$";
         error_reporting(E_ERROR);
-        foreach ($this->uplaces as $uplace)
-        {
-          if (($size < 1000) && preg_match('/' . $regex . '/u', $uplace->name))
-          {
+        foreach ($this->uplaces as $uplace) {
+          if (($size < 1000) && preg_match('/' . $regex . '/u', $uplace->name)) {
             $place->unfolded[$uplace->id] = $uplace;
-          }
-          else if (ereg($regex, $uplace->name))
-          {
+          } elseif (ereg($regex, $uplace->name)) {
             $place->unfolded[$uplace->id] = $uplace;
           }
         }
         error_reporting(E_ERROR | E_WARNING | E_PARSE | E_NOTICE);
       }
-    } 
+    }
   }
 
   private function sn_transitions()
   {
     // Load colored transitions:
-    foreach ($this->cmodel->net->page->transition as $transition)
-    {
+    foreach ($this->cmodel->net->page->transition as $transition) {
       $id = (string) $transition->attributes()['id'];
       $name = (string) $transition->name->text;
       $ctransition = new Transition();
@@ -169,11 +135,9 @@ class EquivalentElements
       $ctransition->name = $name;
       $this->ctransitions[$id] = $ctransition;
     }
-    if ($this->umodel)
-    {
+    if ($this->umodel) {
       // Load unfolded transitions:
-      foreach ($this->umodel->net->page->transition as $transition)
-      {
+      foreach ($this->umodel->net->page->transition as $transition) {
         $id = (string) $transition->attributes()['id'];
         $name = (string) $transition->name->text;
         $utransition = new Transition();
@@ -182,35 +146,25 @@ class EquivalentElements
         $this->utransitions[$id] = $utransition;
       }
       // For each colored transition, build regex that recognize its unfoldings:
-      if ($this->utransitions)
-      {
-        foreach ($this->ctransitions as $transition)
-        {
+      if ($this->utransitions) {
+        foreach ($this->ctransitions as $transition) {
           $avoids = array ();
-          foreach ($this->ctransitions as $other)
-          {
-            if (($transition != $other) && (strpos($other->name, $transition->name) !== false))
-            { // transition name is a prefix of other name
+          foreach ($this->ctransitions as $other) {
+            if (($transition != $other) && (strpos($other->name, $transition->name) !== false)) { // transition name is a prefix of other name
               $avoids[$other->id] = $other->name;
             }
           }
           $regex = "^{$transition->name}(_[^_]+)*$";
-          foreach ($this->utransitions as $utransition)
-          {
+          foreach ($this->utransitions as $utransition) {
             $check = true;
-            foreach ($avoids as $avoid)
-            {
+            foreach ($avoids as $avoid) {
               $check = $check && (strpos($utransition->name, $avoid) === false);
             }
-            if ($check)
-            {
+            if ($check) {
               error_reporting(E_ERROR);
-              if ((size < 1000) && preg_match('/' . $regex . '/u', $utransition->name))
-              {
+              if ((size < 1000) && preg_match('/' . $regex . '/u', $utransition->name)) {
                 $transition->unfolded[$utransition->id] = $utransition;
-              }
-              else if (ereg($regex, $utransition->name))
-              {
+              } elseif (ereg($regex, $utransition->name)) {
                 $transition->unfolded[$utransition->id] = $utransition;
               }
               error_reporting(E_ERROR | E_WARNING | E_PARSE | E_NOTICE);
@@ -224,8 +178,7 @@ class EquivalentElements
   private function pt_places()
   {
     // Load colored transitions:
-    foreach ($this->umodel->net->page->place as $place)
-    {
+    foreach ($this->umodel->net->page->place as $place) {
       $id = (string) $place->attributes()['id'];
       $name = (string) $place->name->text;
       $uplace = new Place();
@@ -238,8 +191,7 @@ class EquivalentElements
   private function pt_transitions()
   {
     // Load colored transitions:
-    foreach ($this->umodel->net->page->transition as $transition)
-    {
+    foreach ($this->umodel->net->page->transition as $transition) {
       $id = (string) $transition->attributes()['id'];
       $name = (string) $transition->name->text;
       $utransition = new Transition();

--- a/src/MCC/Formula/FormulaUnfolder.php
+++ b/src/MCC/Formula/FormulaUnfolder.php
@@ -3,18 +3,13 @@ namespace MCC\Formula;
 
 error_reporting(-1);
 
-use \Symfony\Component\Console\Input\InputInterface;
-use \Symfony\Component\Console\Output\OutputInterface;
-use \Symfony\Component\Console\Input\InputOption;
-use \MCC\Formula\EquivalentElements;
-
 class FormulaUnfolder
 {
   protected $color_model;
   protected $pt_model;
   private $ep;
 
-  public function __construct ($color_model, $pt_model)
+  public function __construct($color_model, $pt_model)
   {
     #echo "mcc: formula-unfolder: constructing formula unfolder\n";
     $this->color_model = $color_model;
@@ -22,11 +17,10 @@ class FormulaUnfolder
     $this->ep = new EquivalentElements($color_model, $pt_model);
   }
 
-  public function unfold ($formula)
+  public function unfold($formula)
   {
     #echo "mcc: formula-unfolder: unfold: tag " . $formula->getName () . "\n";
-    switch ((string) $formula->getName())
-    {
+    switch ((string) $formula->getName()) {
     case 'all-paths':
     case 'exists-path':
     case 'globally':
@@ -38,10 +32,10 @@ class FormulaUnfolder
     case 'integer-le':
     case 'integer-sum':
     case 'integer-difference':
-      foreach ($formula->children() as $sub)
-      {
+      foreach ($formula->children() as $sub) {
         $this->unfold($sub);
       }
+
       return;
 
     case 'until':
@@ -49,6 +43,7 @@ class FormulaUnfolder
       $reach  = $formula->reach->children()[0];
       $this->unfold($before);
       $this->unfold($reach);
+
       return;
 
     case 'deadlock':
@@ -58,29 +53,27 @@ class FormulaUnfolder
       return;
 
     case 'is-fireable':
-		assert (count ($formula->children ()) == 1);
+        assert (count ($formula->children ()) == 1);
       $id = (string) $formula->transition;
       unset($formula->transition[0]);
-      foreach ($this->ep->ctransitions[$id]->unfolded as $t)
-      {
+      foreach ($this->ep->ctransitions[$id]->unfolded as $t) {
         $formula->addChild('transition', $t->id);
       }
+
       return;
     case 'place-bound':
     case 'tokens-count':
       $ids = array();
-      foreach ($formula->place as $place)
-      {
+      foreach ($formula->place as $place) {
         $ids[] = (string) $place;
       }
       unset($formula->place);
-      foreach ($ids as $id)
-      {
-        foreach ($this->ep->cplaces[$id]->unfolded as $p)
-        {
+      foreach ($ids as $id) {
+        foreach ($this->ep->cplaces[$id]->unfolded as $p) {
           $formula->addChild('place', $p->id);
         }
       }
+
       return;
 
     default:
@@ -89,4 +82,3 @@ class FormulaUnfolder
     }
   }
 }
-

--- a/src/MCC/Formula/Place.php
+++ b/src/MCC/Formula/Place.php
@@ -1,8 +1,6 @@
 <?php
 namespace MCC\Formula;
 
-use \MCC\Formula\Domain;
-
 class Place
 {
   public $id;
@@ -10,5 +8,3 @@ class Place
   public $domain = NULL;
   public $unfolded = array();
 }
-
-

--- a/src/MCC/Formula/SmtFormulaFilter.php
+++ b/src/MCC/Formula/SmtFormulaFilter.php
@@ -1,55 +1,49 @@
 <?php
 namespace MCC\Formula;
 
-use \Symfony\Component\Console\Input\InputInterface;
-use \Symfony\Component\Console\Output\OutputInterface;
-use \Symfony\Component\Console\Input\InputOption;
-
 class SmtFormulaFilter
 {
   private $console_output;
   private $places;
 
-  public function __construct ($console_output, $places)
+  public function __construct($console_output, $places)
   {
     $this->console_output = $console_output;
     $this->places = $places;
   }
 
-  public function filter_out ($formula)
+  public function filter_out($formula)
   {
     // returns true if the formula should be discarded (bad quality); false otherwise
 
     echo "mcc: smt-filter: calling the filtering routine\n";
 
     $result = $this->build_smt_encoding ($formula);
-    if ($result[2] != "")
-    {
+    if ($result[2] != "") {
       $result[0] = $result[0] && $this->call_smt ($result);
     }
+
     return ! $result[0];
   }
 
-  private function build_smt_encoding ($formula)
+  private function build_smt_encoding($formula)
   {
   // Le résultat est un triplet :
   //   * un booléen qui indique si on doit garder la formule ou pas
-  //   * un tableau de nom de variables pour la déclaration (j'utilise le nom des 
-  //     variables comme clé pour être certain de l'unicité des entrées, la valeur 
+  //   * un tableau de nom de variables pour la déclaration (j'utilise le nom des
+  //     variables comme clé pour être certain de l'unicité des entrées, la valeur
   //     associée n'a aucun sens)
   //   * une chaîne de caractère représentant la formule booléenne déjà calculée
     $result = array(true, array(), "");
-    switch ((string) $formula->getName())
-    {
+    switch ((string) $formula->getName()) {
     case 'all-paths':
     case 'exists-path':
     case 'globally':
     case 'finally':
       $sub = $formula->children()[0];
       $result = $this->build_smt_encoding($sub);
-      
-      if ($result[2] != "")
-      {
+
+      if ($result[2] != "") {
         $result[0] = $result[0] && $this->call_smt($result);
       }
 
@@ -59,9 +53,8 @@ class SmtFormulaFilter
     case 'next':
       $sub = $formula->children()[0];
       $result = $this->build_smt_encoding($sub);
-      
-      if ($result[2] != "")
-      {
+
+      if ($result[2] != "") {
         $result[0] = $result[0] && $this->call_smt($result);
       }
 
@@ -72,25 +65,20 @@ class SmtFormulaFilter
       $before = $formula->before->children()[0];
       $reach  = $formula->reach->children()[0];
       $result_b = $this->build_smt_encoding($before);
-      
-      if ($result_b[2] != "")
-      {
+
+      if ($result_b[2] != "") {
         $result_b[0] = $result_b[0] && $this->call_smt($result_b);
       }
 
-      if ($result_b[0])
-      {
+      if ($result_b[0]) {
         $result_r = $this->build_smt_encoding($reach);
-      
-        if ($result_r[2] != "")
-        {
+
+        if ($result_r[2] != "") {
            $result_r[0] = $result_r[0] && $this->call_smt($result_r);
         }
 
         $result[0] = $result_r[0];
-      }
-      else
-      {
+      } else {
         $result[0] = false;
       }
       $result[1] = array();
@@ -104,8 +92,7 @@ class SmtFormulaFilter
     case 'negation':
       $sub = $formula->children()[0];
       $result = $this->build_smt_encoding($sub);
-      if ($result[2] != '')
-      {
+      if ($result[2] != '') {
           $result[2] = '(not ' . $result[2] . ')';
         }
       break;
@@ -132,19 +119,15 @@ class SmtFormulaFilter
     case 'place-bound':
     case 'tokens-count':
       $res = array();
-      foreach ($formula->place as $place)
-      {
+      foreach ($formula->place as $place) {
         $id = (string) $place;
         $name = $this->places[$id]->name;
         $res[] = $name;
         $result[1][$name] = 1;
       }
-      if (count($res) >= 2)
-      {
+      if (count($res) >= 2) {
         $result[2] = '(+ ' . implode(' ', $res) . ')';
-      }
-      else
-      {
+      } else {
         $result[2] = $res[0];
       }
 //    $this->console_output->writeln($result[2]);
@@ -164,29 +147,24 @@ class SmtFormulaFilter
     $result = array(true, array(), "");
     $form = array();
     $found = false;
-    foreach ($formula->children() as $sub)
-    {
+    foreach ($formula->children() as $sub) {
       $res = $this->build_smt_encoding($sub);
-      if (! $res[0])
-      {
+      if (! $res[0]) {
         $result[0] = false;
         $result[1] = array();
         $result[2] = "";
 
         break;
       }
-      if ($res[2] != '')
-      {
+      if ($res[2] != '') {
         $found = true;
         $form[] = $res[2];
-        foreach ($res[1] as $var => $val)
-        {
+        foreach ($res[1] as $var => $val) {
           $result[1][$var] = $val;
         }
       }
     }
-    if ($found)
-    {
+    if ($found) {
       $result[2] = '(' . $operator . ' ' . implode(' ', $form) . ')';
     }
 //  $this->console_output->writeln($result[2]);
@@ -196,47 +174,42 @@ class SmtFormulaFilter
   private function call_smt($result)
   {
     $decl = '';
-    foreach ($result[1] as $var => $val)
-    {
+    foreach ($result[1] as $var => $val) {
       $decl = '(declare-fun ' . $var . " () Int)\n" . $decl;
     }
     $to_verify = "(set-logic QF_LIA)\n" . $decl . '(assert ' . $result[2] .  ')' .  "\n(check-sat)\n";
 //    $this->console_output->writeln("Vérification 1 : \n" . $to_verify);
 
-	 $tmp_file_path = tempnam ("/tmp/", "mcc.formulacheck.smt.");
-	 echo "mcc: smt-filter: here is the program:\n";
-	 echo $to_verify;
-	 #echo "smt: saving to '$tmp_file_path'\n";
+     $tmp_file_path = tempnam ("/tmp/", "mcc.formulacheck.smt.");
+     echo "mcc: smt-filter: here is the program:\n";
+     echo $to_verify;
+     #echo "smt: saving to '$tmp_file_path'\n";
     file_put_contents ($tmp_file_path, $to_verify);
     $output = array();
     $command = 'z3 -smt2 ' . $tmp_file_path;
     exec($command, $output);
-	 echo "mcc: smt-filter: answer: $output[0]\n";
-    if ($output[0] != 'sat')
-    {
+     echo "mcc: smt-filter: answer: $output[0]\n";
+    if ($output[0] != 'sat') {
 //      $this->console_output->writeln('unsat 1 ! : ' . $output[0]);
       $res = false;
-    }
-    else
-    {
+    } else {
       $res = true;
       $to_verify = "(set-logic QF_LIA)\n" . $decl . '(assert (not ' .  $result[2] . "))\n(check-sat)\n";
 //      $this->console_output->writeln("Vérification 2 : \n" . $to_verify);
-	   echo "mcc: smt-filter: same call: another program:\n";
-	   echo $to_verify;
+       echo "mcc: smt-filter: same call: another program:\n";
+       echo $to_verify;
       file_put_contents($tmp_file_path, $to_verify);
       $output = array();
       $command = 'z3 -smt2 ' . $tmp_file_path;
       exec($command, $output);
-	   echo "mcc: smt-filter: answer: $output[0]\n";
-      if ($output[0] != 'sat')
-      {
+       echo "mcc: smt-filter: answer: $output[0]\n";
+      if ($output[0] != 'sat') {
 //        $this->console_output->writeln('unsat 2 ! : ' . $output[0]);
         $res = false;
       }
     }
 
-	 unlink ($tmp_file_path);
+     unlink ($tmp_file_path);
 
     return $res;
   }

--- a/src/MCC/Formula/Transition.php
+++ b/src/MCC/Formula/Transition.php
@@ -7,5 +7,3 @@ class Transition
   public $name;
   public $unfolded = array();
 }
-
-

--- a/src/MCC/Import/CSV2013.php
+++ b/src/MCC/Import/CSV2013.php
@@ -11,89 +11,100 @@ use \MCC\Data\Tool;
 use \External\ParseCSV;
 use \Symfony\Component\Console\Command\Command;
 use \Symfony\Component\Console\Output\OutputInterface;
-use \Symfony\Component\Console\Helper\ProgressHelper;
 
-class CSV2013 {
-
+class CSV2013
+{
   private $resultsdir;
   private $year;
 
-  public function __construct($year, $dir) {
+  public function __construct($year, $dir)
+  {
     $this -> year = $year;
     $this -> resultsdir = $dir;
   }
 
-  function tool($name) {
+  public function tool($name)
+  {
     global $entityManager;
     $result = $entityManager -> getRepository('\MCC\Data\Tool') -> findBy(array('name' => $name));
     if (count($result) == 0) {
       $result = new Tool($name);
       $entityManager -> flush();
-    } else if (count($result) == 1) {
+    } elseif (count($result) == 1) {
       $result = $result[0];
     } else {
       throw new Exception('');
     }
+
     return $result;
   }
 
-  function formalism($name) {
+  public function formalism($name)
+  {
     global $entityManager;
     $result = $entityManager -> getRepository('\MCC\Data\Formalism') -> findBy(array('acronym' => $name));
     if (count($result) == 0) {
       $result = new Formalism($name);
       $entityManager -> flush();
-    } else if (count($result) == 1) {
+    } elseif (count($result) == 1) {
       $result = $result[0];
     } else {
       throw new Exception('');
     }
+
     return $result;
   }
 
-  function model($name) {
+  public function model($name)
+  {
     global $entityManager;
     $result = $entityManager -> getRepository('\MCC\Data\Model') -> findBy(array('name' => $name));
     if (count($result) == 0) {
       $result = new Model($name);
       $entityManager -> flush();
-    } else if (count($result) == 1) {
+    } elseif (count($result) == 1) {
       $result = $result[0];
     } else {
       throw new Exception('');
     }
+
     return $result;
   }
 
-  function instance(Model $model, Formalism $formalism, $parameter) {
+  public function instance(Model $model, Formalism $formalism, $parameter)
+  {
     global $entityManager;
     $result = $entityManager -> getRepository('\MCC\Data\Instance') -> findBy(array('formalism' => $formalism, 'parameter' => $parameter));
     if (count($result) == 0) {
       $result = new Instance($model, $formalism, $parameter);
       $entityManager -> flush();
-    } else if (count($result) == 1) {
+    } elseif (count($result) == 1) {
       $result = $result[0];
     } else {
       throw new Exception('');
     }
+
     return $result;
   }
 
-  function contest($name) {
+  public function contest($name)
+  {
     global $entityManager;
     $result = $entityManager -> getRepository('\MCC\Data\Contest') -> findBy(array('edition' => $name));
     if (count($result) == 0) {
       $result = new Contest($name);
       $entityManager -> flush();
-    } else if (count($result) == 1) {
+    } elseif (count($result) == 1) {
       $result = $result[0];
     } else {
       throw new Exception('');
     }
+
     return $result;
   }
 
-  function call(Command $command, OutputInterface $output) {
+  public function call(Command $command, OutputInterface $output)
+  {
     global $entityManager;
     $contest = $this -> contest($this -> year);
     $resource = opendir($this -> resultsdir);


### PR DESCRIPTION
i have worked a bit on the spec tooling (in a fork of the project : https://github.com/saucisson/formulas) :
- model conversion to spec is faster, because it was too long on big models;
- formula generation seems to work, even when the original formula is not in CNF; but the conversion require python/sympy and is thus slow;
- there is a new formula generator specialized for spec constraints;
- added a small script to download the models archive and generate formulas.

Generated formulas are totally random. You can get better ones by removing the "--no-filtering" flag. But it require a tool made by Cesar Rodriguez to check formulas.

Look at https://github.com/saucisson/formulas/blob/model-effciency/spec.sh
To run it, don't forget to install python and python-sympy.
